### PR TITLE
Add devcontainer configuration for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
+  "name": "ckUtilities",
+  "image": "mcr.microsoft.com/devcontainers/cpp:1-ubuntu-22.04",
+  "features": {
+    "ghcr.io/devcontainers/features/cmake:1": {
+      "version": "3.27.6"
+    },
+    "ghcr.io/devcontainers/features/ninja:1": {},
+    "ghcr.io/devcontainers/features/llvm:1": {
+      "version": "15"
+    },
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y pandoc texinfo dpkg-dev rpm ccache lcov && cmake --preset dev",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools-extension-pack",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake",
+        "ms-azuretools.vscode-docker"
+      ],
+      "settings": {
+        "cmake.configureOnOpen": false,
+        "cmake.generator": "Ninja",
+        "cmake.buildDirectory": "${workspaceFolder}/build/dev",
+        "cmake.options.statusBarVisibility": "compact",
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "ms-vscode.cpptools"
+      }
+    }
+  },
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=${localEnv:HOME}/.cache/ccache,target=/home/vscode/.cache/ccache,type=bind,consistency=cached,create=true"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a devcontainer definition targeting the C++ base image
- provision build tooling, documentation dependencies, and useful VS Code extensions
- prime builds via the dev preset and mount a persistent ccache directory

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfc7d30c488330b256003464d619e6