### PR TITLE
Fix macOS curses setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install ninja
+          brew install ninja ncurses
+          NCURSES_PREFIX=$(brew --prefix ncurses)
+          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}$NCURSES_PREFIX" >> "$GITHUB_ENV"
+          echo "CPATH=${CPATH:+$CPATH:}$NCURSES_PREFIX/include" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=${LIBRARY_PATH:+$LIBRARY_PATH:}$NCURSES_PREFIX/lib" >> "$GITHUB_ENV"
 
       - name: Configure
         run: cmake --preset dev
@@ -79,7 +83,11 @@ jobs:
       - name: Install packaging dependencies
         run: |
           brew update
-          brew install ninja
+          brew install ninja ncurses
+          NCURSES_PREFIX=$(brew --prefix ncurses)
+          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}$NCURSES_PREFIX" >> "$GITHUB_ENV"
+          echo "CPATH=${CPATH:+$CPATH:}$NCURSES_PREFIX/include" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=${LIBRARY_PATH:+$LIBRARY_PATH:}$NCURSES_PREFIX/lib" >> "$GITHUB_ENV"
 
       - name: Configure
         run: cmake --preset pkg -DCMAKE_INSTALL_PREFIX=.


### PR DESCRIPTION
## Summary
- install the Homebrew ncurses formula for macOS jobs
- export ncurses include and library paths so CMake can locate curses headers
- apply the same configuration to the macOS packaging workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfcab1bc7c83309c0a03928ed9e1fc