### PR TITLE
Refactor devcontainer to avoid GHCR features

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      gnupg \
+      lsb-release \
+      software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc \
+      | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
+      > /etc/apt/sources.list.d/kitware.list
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      cmake \
+      ninja-build \
+      clang-15 \
+      clang-tidy-15 \
+      lld-15 \
+      llvm-15-dev \
+      git \
+      pandoc \
+      texinfo \
+      dpkg-dev \
+      rpm \
+      ccache \
+      lcov \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 150 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 150 \
+    && update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 150
+
+RUN CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}') \
+    && if dpkg --compare-versions "${CMAKE_VERSION}" lt 3.27; then \
+         echo "CMake 3.27+ is required, but ${CMAKE_VERSION} is installed." >&2; \
+         exit 1; \
+       fi
+
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
   "name": "ckUtilities",
-  "image": "mcr.microsoft.com/devcontainers/cpp:1-ubuntu-22.04",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "postCreateCommand": ".devcontainer/postCreate.sh",
   "customizations": {
     "vscode": {

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,44 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends ca-certificates curl gnupg lsb-release software-properties-common
-
-KITWARE_KEYRING="/usr/share/keyrings/kitware-archive-keyring.gpg"
-KITWARE_LIST="/etc/apt/sources.list.d/kitware.list"
-
-if [[ ! -f "${KITWARE_KEYRING}" ]]; then
-  curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo gpg --dearmor -o "${KITWARE_KEYRING}"
-fi
-
-if [[ ! -f "${KITWARE_LIST}" ]]; then
-  echo "deb [signed-by=${KITWARE_KEYRING}] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | sudo tee "${KITWARE_LIST}" >/dev/null
-fi
-
-sudo apt-get update
-sudo apt-get install -y --no-install-recommends \
-  cmake \
-  ninja-build \
-  clang-15 \
-  clang-tidy-15 \
-  lld-15 \
-  llvm-15-dev \
-  git \
-  pandoc \
-  texinfo \
-  dpkg-dev \
-  rpm \
-  ccache \
-  lcov
-
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 150
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 150
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 150
-
-CMAKE_VERSION=$(cmake --version | head -n1 | awk '{print $3}')
-if dpkg --compare-versions "${CMAKE_VERSION}" lt 3.27; then
-  echo "CMake 3.27+ is required, but ${CMAKE_VERSION} is installed." >&2
-  exit 1
-fi
-
 cmake --preset dev || true


### PR DESCRIPTION
## Summary
- build the Codespaces container from a custom Dockerfile that installs CMake, LLVM, Ninja, Git, and related tooling without relying on devcontainer Features hosted on GHCR
- update the devcontainer definition to use the new Dockerfile and keep the existing VS Code configuration
- simplify the post-create hook now that dependencies are provisioned during the image build

## Testing
- not run (devcontainer configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68cfcb80e9d88330b814689f8f15207f