### PR TITLE
Fix macOS packaging archive contents

### DIFF
--- a/packaging/CPackConfig.cmake
+++ b/packaging/CPackConfig.cmake
@@ -11,7 +11,12 @@ set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY ON)
 if(APPLE)
   set(CPACK_GENERATOR "TGZ")
   set(CPACK_PACKAGE_FILE_NAME "ck-utilities-${CPACK_PACKAGE_VERSION}-macos")
-  set(CPACK_PACKAGING_INSTALL_PREFIX ".")
+  # Use an empty packaging install prefix so the macOS archive contains the
+  # installed tree directly under the top-level directory. Using "." here
+  # causes CPack to generate an empty top-level directory (and therefore a
+  # near-empty archive) because the staged install ends up under a sibling
+  # directory named with a trailing dot.
+  set(CPACK_PACKAGING_INSTALL_PREFIX "")
 else()
   set(CPACK_GENERATOR "TGZ;DEB;RPM")
   string(TOLOWER "${CMAKE_SYSTEM_NAME}" _cpack_system)


### PR DESCRIPTION
## Summary
- ensure the macOS TGZ package uses an empty packaging install prefix so that the staged files end up inside the archive
- document the rationale to avoid generating an empty top-level directory when CPack stages files under a trailing-dot folder

## Testing
- cmake --build build/pkg
- (cd build/pkg && cpack -G TGZ)


------
https://chatgpt.com/codex/tasks/task_e_68cfcf0ee5048330a6533bc66ccaafaa