### PR TITLE
Rename json-view app binary to ck-json-view

### DIFF
--- a/docs/tools/json-view.md
+++ b/docs/tools/json-view.md
@@ -1,14 +1,14 @@
-# json-view — Interactive JSON browser
+# ck-json-view — Interactive JSON browser
 
 ## SYNOPSIS
 
 ```
-ckjsonview [path]
+ck-json-view [path]
 ```
 
 ## DESCRIPTION
 
-`ckjsonview` embeds the Turbo Vision frontend from the standalone
+`ck-json-view` embeds the Turbo Vision frontend from the standalone
 `json-view` project so that CkTools gains an interactive JSON browser on
 Day 1.  The viewer presents parsed JSON data as a tree where each node
 is decorated with friendly icons, Unicode box-drawing characters, and
@@ -16,12 +16,12 @@ previews for common types.  Search results are highlighted inline, and
 clipboard export uses OSC 52 sequences when supported by the terminal.
 
 If a file path is provided on the command line it will be opened on
-startup.  Otherwise `ckjsonview` prompts for a file via the Turbo Vision
+startup.  Otherwise `ck-json-view` prompts for a file via the Turbo Vision
 file picker.
 
 ## OPTIONS
 
-`ckjsonview` accepts the same flags as the upstream project:
+`ck-json-view` accepts the same flags as the upstream project:
 
 * `--help` – display usage information.
 * `--version` – show the embedded json-view version string.
@@ -31,18 +31,18 @@ file picker.
 Open a JSON document from the current directory:
 
 ```
-ckjsonview example.json
+ck-json-view example.json
 ```
 
 Launch the viewer and choose a file interactively:
 
 ```
-ckjsonview
+ck-json-view
 ```
 
 ## EXIT STATUS
 
-`ckjsonview` exits with status 0 on success and non-zero on failure.
+`ck-json-view` exits with status 0 on success and non-zero on failure.
 
 ## SEE ALSO
 

--- a/packaging/CPackConfig.cmake
+++ b/packaging/CPackConfig.cmake
@@ -1,7 +1,7 @@
 set(CPACK_PACKAGE_NAME "ck-utilities")
 set(CPACK_PACKAGE_VENDOR "ckUtilities Project")
 set(CPACK_PACKAGE_CONTACT "maintainers@ckutilities.dev")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Turbo Vision utilities including the ckjsonview JSON viewer")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Turbo Vision utilities including the ck-json-view JSON viewer")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")

--- a/packaging/macos/install.sh
+++ b/packaging/macos/install.sh
@@ -4,17 +4,17 @@ set -euo pipefail
 PREFIX="${1:-/usr/local}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-BIN_SOURCE="${ROOT_DIR}/bin/ckjsonview"
+BIN_SOURCE="${ROOT_DIR}/bin/ck-json-view"
 LICENSE_SOURCE="${ROOT_DIR}/share/licenses/ck-utilities/LICENSE"
 DOC_DIR="${ROOT_DIR}/share/doc/ck-utilities"
 
 if [[ ! -x "${BIN_SOURCE}" ]]; then
-  echo "ckjsonview binary not found at ${BIN_SOURCE}" >&2
+  echo "ck-json-view binary not found at ${BIN_SOURCE}" >&2
   exit 1
 fi
 
 install -d "${PREFIX}/bin"
-install -m 0755 "${BIN_SOURCE}" "${PREFIX}/bin/ckjsonview"
+install -m 0755 "${BIN_SOURCE}" "${PREFIX}/bin/ck-json-view"
 
 if [[ -f "${LICENSE_SOURCE}" ]]; then
   install -d "${PREFIX}/share/licenses/ck-utilities"
@@ -28,4 +28,4 @@ if [[ -d "${DOC_DIR}" ]]; then
   done
 fi
 
-echo "ckjsonview installed to ${PREFIX}/bin."
+echo "ck-json-view installed to ${PREFIX}/bin."

--- a/src/tools/json-view/CMakeLists.txt
+++ b/src/tools/json-view/CMakeLists.txt
@@ -37,6 +37,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
 )
 
 add_ck_tool(ckjsonview
+  OUTPUT_NAME "ck-json-view"
   SOURCES
     src/json-view-app.cpp
   LIBRARIES

--- a/src/tools/json-view/src/json-view-app.cpp
+++ b/src/tools/json-view/src/json-view-app.cpp
@@ -354,7 +354,7 @@ void JsonViewApp::handleEvent(TEvent &event)
             break;
         case cmAbout:
         {
-            std::string msg = std::string("json-view-app ") + JSON_VIEW_VERSION +
+            std::string msg = std::string("ck-json-view ") + JSON_VIEW_VERSION +
                               "\nDeveloper: " + kDeveloperName;
             messageBox(msg.c_str(), mfInformation | mfOKButton);
             break;


### PR DESCRIPTION
## Summary
- install the Turbo Vision JSON viewer as `ck-json-view` to match the ck-utilities naming scheme
- update documentation and packaging scripts to reference the new executable name
- refresh the in-app About dialog to display the ck-json-view branding

## Testing
- cmake --preset dev
- cmake --build --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68cfd6be94a88330bc29fa42ff23956d