### PR TITLE
Add AI backend implementation plan

### DIFF
--- a/implementation/ai/00-overview.md
+++ b/implementation/ai/00-overview.md
@@ -1,0 +1,30 @@
+# AI Backend Implementation Plan — Overview
+
+This directory contains the implementation playbooks for turning the concepts in `docs/ai-design.md`, `README.md`, `COMPILE.md`, and `IDEA.md` into an offline-first AI backend for CkTools.
+
+## Guiding Principles
+
+1. **Offline by default** — all inference runs locally; only allow manual model downloads.
+2. **Minimal dependencies** — reuse existing build + packaging tooling and vendor only what we must (e.g., `llama.cpp`).
+3. **C++-first integration** — expose AI capabilities through `libckai_*` libraries, consistent with our current monorepo layout and CMake workflows.
+4. **Reproducible & testable** — every phase must add tests and CI hooks as described in `COMPILE.md`.
+5. **Package-ready** — update CPack + distro specs alongside new binaries so `.deb`, `.rpm`, and tarball builds keep working.
+
+## Phase Structure
+
+Each phase has its own markdown file in this folder. Follow them sequentially:
+
+1. [Phase 0 — Scaffolding](01-phase0-scaffolding.md)
+2. [Phase 1 — Embeddings & Index](02-phase1-embeddings-index.md)
+3. [Phase 2 — RAG & ckqna](03-phase2-rag-ckqna.md)
+4. [Phase 3 — Tool Integrations](04-phase3-tool-integrations.md)
+5. [Phase 4 — Quality & Optional Backends](05-phase4-quality-extensions.md)
+
+Each document contains:
+
+* **Prerequisites** — what must be ready before you start.
+* **Implementation steps** — ordered tasks with file paths, build targets, and code integration notes.
+* **Validation checklist** — commands to run (build, tests, packaging) per `COMPILE.md`.
+* **Deliverables** — artifacts or code expected in the PR for that phase.
+
+> ⚠️ Do not skip ahead. Later phases assume the interfaces, configs, and packaging from earlier steps are in place.

--- a/implementation/ai/01-phase0-scaffolding.md
+++ b/implementation/ai/01-phase0-scaffolding.md
@@ -1,0 +1,62 @@
+# Phase 0 — Scaffolding & Runtime Skeleton
+
+**Goal:** Lay down the minimal runtime (`libckai_core`), vendor the primary backend (`llama.cpp`), and ship the `ckchat` prototype with configuration + build plumbing. This unlocks all later phases.
+
+## Prerequisites
+
+* Read `docs/ai-design.md` sections 1–5 and 9–12.
+* Understand the build flow in `COMPILE.md` (CMake presets, library layout, packaging via CPack).
+* Ensure you have local write access to the `third_party/` directory and can update CMake toolchain files.
+
+## Implementation Steps
+
+1. **Vendor llama.cpp**
+   1. Create `third_party/llama.cpp/` by adding the upstream source at a pinned commit (document the commit hash in `third_party/llama.cpp/README.cktools.md`). No git submodules.
+   2. Add a `third_party/llama.cpp/CMakeLists.txt` wrapper if upstream does not ship one suitable for embedding. Configure it to expose a static library target named `llama_cpp`.
+   3. Update the top-level `CMakeLists.txt` to include a new option `CKAI_BACKEND_LLAMA` (default `ON`) and add `add_subdirectory(third_party/llama.cpp)` guarded by the option.
+   4. For reproducibility, add any required patch files under `third_party/patches/llama.cpp/` and document how to apply them in the README.
+
+2. **Create core AI library skeleton**
+   1. Under `lib/`, add a new directory `ckai_core/` with `CMakeLists.txt`, headers in `include/ck/ai/`, and a minimal `src/` directory.
+   2. Implement placeholder classes matching the API sketches in `docs/ai-design.md §5.1`, but initially stub out methods with TODOs and deterministic return values.
+   3. Expose a CMake target `ckai_core` that links to `llama_cpp` when `CKAI_BACKEND_LLAMA=ON`. When the backend is off, provide a compile-time error if code attempts to build AI tools.
+   4. Register unit test targets under `tests/unit/ckai_core/` using GoogleTest; create a `CMakeLists.txt` that hooks into the existing test tree. Add simple tests that the stubs return expected placeholder values.
+
+3. **Configuration plumbing**
+   1. Introduce a new config loader in `ckcore` (or reuse existing config facilities) to read `~/.config/cktools/ckai.toml`. For Phase 0 this can parse only `llm.model`, `llm.threads`, and `limits.max_output_tokens`.
+   2. Provide a sample config template at `configs/ckai.example.toml` as described in `docs/ai-design.md §4`.
+   3. Ensure the config path is mentioned in README material or existing help output as appropriate.
+
+4. **Prototype `ckchat` CLI/TUI**
+   1. Scaffold `src/tools/ckchat/` using the existing helper (`add_ck_tool`). Implement a CLI front-end that wires the stubs in `ckai_core` to accept a prompt and echo a placeholder response.
+   2. Implement a minimal TUI using shared widgets from `ckui` (status line, scrolling output) to stream tokens. For Phase 0, stream the stub response character-by-character with a timer to exercise the event loop.
+   3. Add integration tests under `tests/integration/ckchat/` that run the CLI in non-interactive mode.
+
+5. **Build system wiring**
+   1. Update `cmake/AddCkTool.cmake` if needed so AI tools can declare dependencies on `ckai_core`.
+   2. Add `ckchat` to the default build by including it in `src/tools/CMakeLists.txt`.
+   3. Extend `CMakePresets.json` presets (`dev`, `asan`, `pkg`) to toggle `CKAI_BACKEND_LLAMA` and ensure builds fail fast if the backend is off but `ckchat` is requested.
+
+6. **Packaging & CI**
+   1. Update `packaging/CPackConfig.cmake` to include the new binaries (`ckchat`) and install paths for `configs/ckai.example.toml`.
+   2. Ensure `install(TARGETS ...)` directives for `ckai_core` headers and libraries are in place so packages include them.
+   3. Modify GitHub Actions workflows to build and test the new targets (update `cmake --build` invocations and `ctest` filters). Verify that sanitizer and packaging jobs cover `ckchat`.
+
+## Validation Checklist
+
+Run these commands locally before opening a PR:
+
+* `cmake --preset dev`
+* `cmake --build build/dev`
+* `ctest --test-dir build/dev --output-on-failure`
+* `cmake --build build/pkg -t package`
+
+Confirm the resulting `.deb`/`.rpm` contain `ckchat`, `libckai_core` headers, and the sample config.
+
+## Deliverables
+
+* `third_party/llama.cpp` with pinned source + documentation.
+* New `lib/ckai_core` target and headers in `include/ck/ai/`.
+* Stubbed `ckchat` CLI/TUI wired into the build.
+* Sample AI config file and updated packaging/CI definitions.
+* Passing builds and tests on the CI matrix.

--- a/implementation/ai/02-phase1-embeddings-index.md
+++ b/implementation/ai/02-phase1-embeddings-index.md
@@ -1,0 +1,66 @@
+# Phase 1 — Embeddings & Flat Index
+
+**Goal:** Add embeddings support (`Llm::embed`), introduce `libckai_embed`, and provide CLI utilities (`ckembed`, `ckindex`) with a simple on-disk vector index. This enables offline RAG pipelines in later phases.
+
+## Prerequisites
+
+* Phase 0 is complete and merged.
+* The llama.cpp backend builds and can stream dummy tokens via `ckchat`.
+* Review `docs/ai-design.md` sections 5.2–6 and 8.
+
+## Implementation Steps
+
+1. **Extend llama backend bindings**
+   1. Enhance the backend adapter in `lib/ckai_core` to call llama.cpp embedding functions. Make the implementation conditional on the backend supporting embeddings; emit a descriptive runtime error otherwise.
+   2. Update `ck::ai::Llm::embed` to return `std::vector<float>` (or a thin wrapper) rather than placeholder strings. Ensure the dimension is discoverable at runtime.
+   3. Add unit tests covering: embedding dimension detection, deterministic embeddings with fixed seeds, and error handling when the backend is unavailable.
+
+2. **Introduce `libckai_embed`**
+   1. Create `lib/ckai_embed/` with headers under `include/ck/ai/` for chunking helpers, batching, cosine similarity, and deduplication utilities per `docs/ai-design.md §5.2`.
+   2. Implement pure functions for:
+      * Text chunking with overlap (configurable size/stride).
+      * Hash-based deduplication of embeddings.
+      * Cosine similarity calculation.
+   3. Provide unit tests in `tests/unit/ckai_embed/` for all helper functions (use synthetic vectors so tests run fast offline).
+
+3. **Flat vector index**
+   1. Implement the `ck::ai::Index` class with a naive L2/cosine search over in-memory vectors backed by an on-disk `.ckv` file.
+   2. Store metadata (document id, offsets) alongside vectors in a simple binary format; document the format in `docs/ai-design.md` or a new developer note if needed.
+   3. Add serialization tests to ensure indexes survive save/load cycles.
+
+4. **Command-line tools**
+   1. Scaffold `ckembed` and `ckindex` in `src/tools/` using `add_ck_tool`.
+   2. `ckembed`: read files/stdin, chunk via `libckai_embed`, call `Llm::embed`, and write `.vec` files (include metadata JSON/YAML for provenance). Provide `--json` output to print embeddings inline for scripting.
+   3. `ckindex`: load `.vec` files, add them to the flat index, and support both index build (`--build`) and query (`--query`) modes. Return top-k hits with similarity scores.
+   4. Wire CLIs to respect `~/.config/cktools/ckai.toml` for model paths and batch sizes.
+   5. Add integration tests simulating small corpora using temporary files. Keep fixtures tiny so they run quickly.
+
+5. **Docs & examples**
+   1. Update `docs/tools/` (create new files if needed) with usage instructions for `ckembed` and `ckindex`, including the offline workflow for preparing models.
+   2. Add a brief how-to section in `docs/ai-design.md` or a new doc describing the `.ckv` file format and recommended chunk sizes.
+
+6. **Build, packaging, CI updates**
+   1. Extend CMake targets, install rules, and CPack configuration to include the new tools and libraries.
+   2. Update GitHub Actions workflows so `ckembed`/`ckindex` are built and tested in all jobs.
+   3. Ensure packages install vector index headers and binaries; update `packaging/deb` and `packaging/rpm` metadata if additional runtime dependencies (e.g., `libstdc++` requirements) arise. Keep dependencies minimal.
+
+## Validation Checklist
+
+Run locally:
+
+* `cmake --preset dev`
+* `cmake --build build/dev -t ckembed ckindex`
+* `ctest --test-dir build/dev --output-on-failure -L ckai`
+* `cmake --build build/pkg -t package`
+
+Additionally, run a manual smoke test:
+
+* `./build/dev/src/tools/ckembed/ckembed --model ~/.local/share/cktools/models/embed/<your-model>.gguf sample.txt`
+* `./build/dev/src/tools/ckindex/ckindex --build sample.ckv sample.vec`
+
+## Deliverables
+
+* Functional `Llm::embed` implementation with unit tests.
+* New `libckai_embed` helpers and tests.
+* Working `ckembed` and `ckindex` CLIs with docs.
+* Packaging/CI updates ensuring the new tools ship in `.deb`, `.rpm`, and tarball outputs.

--- a/implementation/ai/03-phase2-rag-ckqna.md
+++ b/implementation/ai/03-phase2-rag-ckqna.md
@@ -1,0 +1,59 @@
+# Phase 2 — RAG Pipeline & `ckqna`
+
+**Goal:** Implement retrieval-augmented generation using the local index, ship the `ckqna` tool, and connect AI helpers into `cktext`. This phase delivers end-to-end offline Q&A on local docs.
+
+## Prerequisites
+
+* Phase 1 completed and merged.
+* Local indexes can be built with `ckindex` and queried via the CLI.
+* Familiarize yourself with `docs/ai-design.md` sections 6–8 and 13 (Phase 2).
+
+## Implementation Steps
+
+1. **Prompt templates & formatting**
+   1. Add prompt template helpers under `lib/ckai_core/prompts/` to render the context-grounded templates described in the design doc. Include system messages enforcing “answer only from context.”
+   2. Provide unit tests verifying template output for sample inputs (multiple context chunks, citations, empty results).
+
+2. **RAG orchestrator**
+   1. Implement a new component (e.g., `ck::ai::RagSession`) in `libckai_core` that wires together chunk retrieval, prompt building, and streaming generation.
+   2. Support configurable retrieval parameters (top-k, score threshold) sourced from `ckai.toml`.
+   3. Enforce safeguards: if retrieval returns low scores, emit “I don’t know” per design guidance.
+   4. Add integration-style unit tests using tiny synthetic indexes to ensure deterministic behavior with seeded models (use mock backend stubs if full llama.cpp is too heavy for unit tests).
+
+3. **`ckqna` CLI/TUI**
+   1. Scaffold `src/tools/ckqna/` with CLI flags for selecting an index, specifying retrieval limits, and toggling JSON output.
+   2. Implement TUI components showing streaming answers with citation list; integrate with shared UI widgets (status line, cancel hotkey `Esc`).
+   3. Provide integration tests that query a sample index and assert that citations include file + line metadata.
+
+4. **`cktext` AI pane**
+   1. Add an `F4` (or next available key) AI help pane in `cktext` per design doc §7.
+   2. Hook the pane into `libckai_core` so it can:
+      * Rewrite selected text.
+      * Generate outlines from titles.
+   3. Respect offline rules—only use the local model specified in config. Ensure the UI exposes the equivalent CLI commands (`ckchat`, `ckembed`, `ckindex`) for transparency.
+   4. Add unit/UI tests where possible (e.g., verifying command strings) and update manual test scripts.
+
+5. **Documentation & samples**
+   1. Extend `docs/tools/ckqna.md` (create if missing) with usage examples, JSON schema, and offline setup instructions.
+   2. Update `docs/ai-design.md` section 6 with concrete RAG workflow diagrams/screenshots if available.
+   3. Document how `cktext` exposes AI features in its manual page.
+
+6. **Build, packaging, CI**
+   1. Wire `ckqna` into the build via `src/tools/CMakeLists.txt` and ensure install rules copy any new assets.
+   2. Update `packaging/CPackConfig.cmake` to include `ckqna` binaries and mark them in package descriptions.
+   3. Extend CI workflows to run new integration tests and capture coverage for RAG components (update `coverage` preset expectations).
+
+## Validation Checklist
+
+* `cmake --preset dev`
+* `cmake --build build/dev -t ckqna cktext`
+* `ctest --test-dir build/dev --output-on-failure -L ckai`
+* `./build/dev/src/tools/ckqna/ckqna --index test-data/test.ckv --question "What is ckfind?"`
+* `cmake --build build/pkg -t package`
+
+## Deliverables
+
+* Prompt templating utilities and RAG orchestrator in `libckai_core`.
+* Functional `ckqna` CLI/TUI with streaming answers and citations.
+* `cktext` AI pane that reuses backend libraries and surfaces equivalent CLI commands.
+* Updated docs, packaging, and CI covering the new workflows.

--- a/implementation/ai/04-phase3-tool-integrations.md
+++ b/implementation/ai/04-phase3-tool-integrations.md
@@ -1,0 +1,61 @@
+# Phase 3 — Tool Integrations
+
+**Goal:** Embed AI helpers into existing CkTools TUIs (`ckfind`, `ckdiff`, `ckdu`, `ckrescue`) while keeping workflows offline, auditable, and cancelable. Deliver polished UX with clear CLI equivalents.
+
+## Prerequisites
+
+* Phase 2 completed and verified.
+* Shared AI libraries (`ckai_core`, `ckai_embed`) are stable, documented, and shipped in packages.
+* Familiarity with the UX rules in `docs/ai-design.md` §7 and the TUI architecture described in `README.md` and `COMPILE.md`.
+
+## Implementation Steps
+
+1. **Common UI glue**
+   1. Add reusable Turbo Vision widgets to `lib/ckui` for displaying AI suggestions, streaming output, and CLI command previews.
+   2. Provide APIs for canceling in-flight generations (`Esc`) and showing stats lines (`tok/s`, context usage, temperature, seed).
+   3. Write unit/UI tests verifying that widgets surface CLI equivalents and respond to cancel events.
+
+2. **`ckfind` enhancements**
+   1. Implement “Explain match” action: capture the selected result, call a new prompt template in `ckai_core`, and render the explanation with references to the matched predicates.
+   2. Implement NL→predicate suggestion: collect user input, run through the model, and output the proposed `find` command. Require explicit confirmation before applying.
+   3. Update integration tests to cover both features in headless mode (simulate input via existing test harnesses).
+
+3. **`ckdiff` helpers**
+   1. Add a panel/button to summarize the current diff hunk, using the prompt from `docs/ai-design.md §16`.
+   2. Implement commit message drafting: pre-fill subject/body, but keep them editable and require user confirmation before staging/applying.
+   3. Ensure tests verify deterministic output for fixed seeds and that commands are logged with CLI equivalents.
+
+4. **`ckdu` safe-delete hints**
+   1. Provide a passive sidebar listing suggested cache/log directories based on AI analysis. Never auto-delete; only tag entries.
+   2. Integrate with the stats widget to show inference cost and allow cancellation.
+   3. Add tests confirming suggestions are informational-only (no delete actions emitted).
+
+5. **`ckrescue` plan explainer**
+   1. When a rescue plan is generated, call into AI to produce a human-readable summary of each step (image, verify, logs).
+   2. Display the summary alongside the exact commands (from the existing plan generator) to reinforce transparency.
+   3. Provide integration tests using canned rescue plans to ensure explanations mention all critical steps.
+
+6. **Accessibility & safety review**
+   1. Audit keybindings, dialogs, and confirmations to ensure AI actions remain opt-in and reversible.
+   2. Update manuals (`docs/tools/*.md`) to describe new AI panes and reference offline configuration.
+   3. Document fallback behavior when AI is disabled (e.g., show tooltips pointing users to `ckmodel add`).
+
+7. **Build, packaging, CI**
+   1. Confirm no new external runtime dependencies were introduced.
+   2. Update automated UI/integration tests and ensure they run in GitHub Actions within existing timeouts.
+   3. Refresh screenshots or asciicasts if documentation relies on them (store assets under `docs/` per existing conventions).
+
+## Validation Checklist
+
+* `cmake --preset dev`
+* `cmake --build build/dev -t ckfind ckdiff ckdu ckrescue`
+* `ctest --test-dir build/dev --output-on-failure -L ai-integration`
+* Manual smoke test each TUI to verify cancelability and CLI previews.
+* `cmake --build build/pkg -t package`
+
+## Deliverables
+
+* Shared AI UI widgets with cancel/stats support.
+* Integrated AI features in `ckfind`, `ckdiff`, `ckdu`, and `ckrescue` that respect offline + safety constraints.
+* Updated documentation and tests demonstrating the new workflows.
+* Passing CI builds including the expanded integration suites.

--- a/implementation/ai/05-phase4-quality-extensions.md
+++ b/implementation/ai/05-phase4-quality-extensions.md
@@ -1,0 +1,56 @@
+# Phase 4 — Quality, Performance, Optional Backends
+
+**Goal:** Polish the AI stack for production: add optional backends (e.g., Whisper ASR, alternative indexes), improve performance/telemetry, and finalize docs + tooling for releases.
+
+## Prerequisites
+
+* Phases 0–3 complete and stable in main.
+* CI pipelines green for multiple consecutive commits.
+* Product requirements for optional features agreed upon (confirm with lead before starting).
+
+## Implementation Steps
+
+1. **Optional Whisper backend (if enabled)**
+   1. Vendor `whisper.cpp` under `third_party/` similar to llama.cpp (pinned commit, documented patches).
+   2. Add CMake option `CKAI_BACKEND_WHISPER` (default `OFF`). When enabled, build a static library `whisper_cpp` and expose ASR APIs under `libckai_core`.
+   3. Implement a thin wrapper `ck::ai::AsrSession` with streaming transcription. Ensure it reuses config + logging infrastructure.
+   4. Ship a CLI (`cktranscribe` or integrate into `ckchat` if approved) with tests and docs.
+
+2. **Advanced index options**
+   1. Add optional HNSW or FAISS-like index support behind `CKAI_INDEX_HNSW`. Keep the default flat index unchanged to avoid new dependencies.
+   2. Implement adapter interfaces so index choice is runtime-configurable via `ckai.toml`.
+   3. Provide benchmarking scripts (under `scripts/ai/`) to compare recall/latency with sample data.
+
+3. **Performance tuning**
+   1. Implement caching layers described in `docs/ai-design.md §10` (prompt summaries, embedding cache, on-disk index shards).
+   2. Add instrumentation hooks to log token/sec, context usage, and cache hits when `CK_DEBUG=1`.
+   3. Provide automated microbenchmarks or perf smoke tests (nightly job) to prevent regressions.
+
+4. **Robustness & safety**
+   1. Expand test suites to cover resource limits (max tokens, RAM soft limits). Simulate limit breaches and ensure graceful errors.
+   2. Fuzz config parsing for `ckai.toml` to harden against malformed input.
+   3. Add localized messages or translation hooks if the team decides to support multiple languages.
+
+5. **Documentation & release readiness**
+   1. Produce comprehensive admin + user guides detailing model management (`ckmodel`), offline operation, and troubleshooting. Update `docs/ai-design.md` appendices accordingly.
+   2. Ensure README and `COMPILE.md` mention the new AI tooling, optional backends, and required build flags.
+   3. Add upgrade notes / migration steps for existing installations (e.g., config schema changes).
+
+6. **Packaging & CI hardening**
+   1. Update CPack scripts to install optional binaries only when the corresponding CMake options are enabled; verify packages remain self-contained without model weights.
+   2. Extend GitHub Actions matrix to run optional backend builds periodically (nightly or on-demand) to ensure they stay healthy.
+   3. Generate SBOMs or dependency manifests if required by release process.
+
+## Validation Checklist
+
+* `cmake --preset dev -DCKAI_BACKEND_WHISPER=ON -DCKAI_INDEX_HNSW=ON` (when testing optional features)
+* `cmake --build build/dev`
+* `ctest --test-dir build/dev --output-on-failure`
+* `cmake --build build/pkg -t package`
+* Run performance smoke tests: `scripts/ai/run-perf-smoke.sh`
+
+## Deliverables
+
+* Optional backend integrations guarded by build flags with documentation.
+* Performance/caching improvements with metrics exposed under debug mode.
+* Hardened tests, packaging, and CI that keep the AI stack stable for releases.


### PR DESCRIPTION
## Summary
- add an `implementation/ai` directory documenting the phased plan for offline AI backend work
- provide detailed guidance for scaffolding, embeddings, RAG, tool integrations, and optional backends aligned with existing build and packaging flows

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cfe71e16888330968d18599f38499b