### PR TITLE
Add global sort controls to ck-du

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # CkTools (working title)
 
 **Status:** concept / exploration.
+
+Current prototypes:
+
+* `ck-json-view` — JSON tree viewer built with Turbo Vision.
+* `ck-du` — disk usage explorer with tree views, file listings, unit and sort controls.
 CkTools aims to bring a set of everyday power utilities to a **Turbo Vision** text UI, so they’re easier to discover and safer to use—while staying fast and script-friendly.
 Target platform: **Linux text-mode terminals**.
 Tech stack: **C++20 (or newer)** + **Turbo Vision**.

--- a/docs/tools/ck-du.md
+++ b/docs/tools/ck-du.md
@@ -1,0 +1,28 @@
+# ck-du — Disk Utilization Explorer
+
+`ck-du` visualizes disk usage with Turbo Vision. Launch it with one or more directory paths to open each location in its own window:
+
+```bash
+ck-du ~/Downloads /var/log
+```
+
+## Features
+
+- **Directory tree** that mimics `ncdu`: sizes, file counts, and nested directory counts are displayed for each entry.
+- **Multiple windows**: pass paths on the command line or open new directories at runtime.
+- **File listings**: press <kbd>F3</kbd> ("View Files") to list files in the selected directory, or <kbd>Shift</kbd>+<kbd>F3</kbd> for a recursive listing that includes subdirectories. File lists show size, owner, group, creation, and modification times.
+- **Unit control**: choose Auto, Bytes, KB, MB, GB, TB, or Blocks from the Units menu. The active unit is marked and updates every open view immediately.
+- **Sort modes**: switch between Unsorted, Name, Size, or Modified order from the Sort menu. The selection applies to every directory tree and file list window instantly.
+
+## Keyboard & menu shortcuts
+
+| Shortcut | Command | Notes |
+| --- | --- | --- |
+| <kbd>F2</kbd> | Open Directory | Type a path to open in a new window. |
+| <kbd>F3</kbd> | View Files | Lists files directly inside the selected directory. |
+| <kbd>Shift</kbd>+<kbd>F3</kbd> | View Files (Recursive) | Includes files from subdirectories. |
+| <kbd>F1</kbd> | About | Shows version and developer. |
+| <kbd>Alt</kbd>+<kbd>X</kbd> | Quit | Exit the application. |
+
+Use the arrow keys to expand/collapse directories, and open multiple directories to compare usage side-by-side. Adjust units from the **Units** menu to switch between automatic scaling, fixed sizes, or 512-byte blocks. Change the ordering of directories and files from the **Sort** menu without reopening windows.
+

--- a/packaging/CPackConfig.cmake
+++ b/packaging/CPackConfig.cmake
@@ -1,7 +1,7 @@
 set(CPACK_PACKAGE_NAME "ck-utilities")
 set(CPACK_PACKAGE_VENDOR "ckUtilities Project")
 set(CPACK_PACKAGE_CONTACT "maintainers@ckutilities.dev")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Turbo Vision utilities including the ck-json-view JSON viewer")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Turbo Vision utilities including ck-json-view and ck-du")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
 include(AddCkTool)
 
 add_subdirectory(json-view)
+add_subdirectory(ck-du)

--- a/src/tools/ck-du/CMakeLists.txt
+++ b/src/tools/ck-du/CMakeLists.txt
@@ -1,0 +1,54 @@
+set(CURSES_NEED_WIDE TRUE)
+find_package(Curses REQUIRED)
+
+if(CURSES_INCLUDE_PATH MATCHES "/ncursesw$")
+  get_filename_component(_curses_parent "${CURSES_INCLUDE_PATH}" DIRECTORY)
+  set(CURSES_INCLUDE_PATH "${_curses_parent}" CACHE PATH "" FORCE)
+  set(CURSES_INCLUDE_DIR "${_curses_parent}" CACHE PATH "" FORCE)
+  set(CURSES_INCLUDE_DIRS "${_curses_parent}" CACHE PATH "" FORCE)
+endif()
+
+include(FetchTurboVision)
+cktools_ensure_tvision()
+
+if(TARGET tvision)
+  target_include_directories(tvision PRIVATE ${CURSES_INCLUDE_DIRS})
+endif()
+
+add_library(ck_du_core STATIC
+  src/disk_usage_core.cpp
+)
+
+target_include_directories(ck_du_core
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(ck_du_core PUBLIC cxx_std_20)
+
+install(TARGETS ck_du_core
+  ARCHIVE DESTINATION lib
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
+)
+
+add_ck_tool(ckdu
+  OUTPUT_NAME "ck-du"
+  SOURCES
+    src/disk-usage-app.cpp
+  LIBRARIES
+    ck_du_core
+    tvision::tvision
+    ${CURSES_LIBRARIES}
+  INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CURSES_INCLUDE_DIRS}
+  DEFINITIONS
+    CK_DU_VERSION="${PROJECT_VERSION}"
+)
+
+target_link_libraries(ck_du_core PRIVATE ${CURSES_LIBRARIES})

--- a/src/tools/ck-du/include/disk_usage_core.hpp
+++ b/src/tools/ck-du/include/disk_usage_core.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ck::du
+{
+
+enum class SizeUnit
+{
+    Auto,
+    Bytes,
+    Kilobytes,
+    Megabytes,
+    Gigabytes,
+    Terabytes,
+    Blocks
+};
+
+enum class SortKey
+{
+    Unsorted,
+    NameAscending,
+    NameDescending,
+    SizeDescending,
+    SizeAscending,
+    ModifiedDescending,
+    ModifiedAscending
+};
+
+struct DirectoryStats
+{
+    std::uintmax_t totalSize = 0;
+    std::size_t fileCount = 0;
+    std::size_t directoryCount = 0;
+};
+
+struct DirectoryNode
+{
+    std::filesystem::path path;
+    DirectoryStats stats;
+    DirectoryNode *parent = nullptr;
+    std::vector<std::unique_ptr<DirectoryNode>> children;
+    std::chrono::system_clock::time_point modifiedTime{};
+    bool expanded = false;
+};
+
+struct FileEntry
+{
+    std::filesystem::path path;
+    std::string displayPath;
+    std::uintmax_t size = 0;
+    std::string owner;
+    std::string group;
+    std::string created;
+    std::string modified;
+    std::chrono::system_clock::time_point createdTime{};
+    std::chrono::system_clock::time_point modifiedTime{};
+};
+
+std::unique_ptr<DirectoryNode> buildDirectoryTree(const std::filesystem::path &rootPath);
+std::vector<FileEntry> listFiles(const std::filesystem::path &directory, bool recursive);
+
+SizeUnit getCurrentUnit() noexcept;
+void setCurrentUnit(SizeUnit unit) noexcept;
+const char *unitName(SizeUnit unit) noexcept;
+std::string formatSize(std::uintmax_t bytes, SizeUnit unit = SizeUnit::Auto);
+
+SortKey getCurrentSortKey() noexcept;
+void setCurrentSortKey(SortKey key) noexcept;
+const char *sortKeyName(SortKey key) noexcept;
+
+} // namespace ck::du
+

--- a/src/tools/ck-du/src/disk-usage-app.cpp
+++ b/src/tools/ck-du/src/disk-usage-app.cpp
@@ -1,0 +1,1155 @@
+#include "disk_usage_core.hpp"
+
+#define Uses_TApplication
+#define Uses_TDeskTop
+#define Uses_TDialog
+#define Uses_TKeys
+#define Uses_TInputLine
+#define Uses_TLabel
+#define Uses_TButton
+#define Uses_TListViewer
+#define Uses_TMenu
+#define Uses_TMenuBar
+#define Uses_TMenuItem
+#define Uses_TOutline
+#define Uses_TScrollBar
+#define Uses_TStatusDef
+#define Uses_TStatusItem
+#define Uses_TStatusLine
+#define Uses_TSubMenu
+#define Uses_TWindow
+#define Uses_MsgBox
+#include <tvision/tv.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <array>
+#include <filesystem>
+#include <limits.h>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace ck::du;
+
+static constexpr const char *kDeveloperName = "Dr. C. Klukas";
+
+static const ushort cmViewFiles = 2001;
+static const ushort cmViewFilesRecursive = 2002;
+static const ushort cmAbout = 2100;
+static const ushort cmUnitAuto = 2200;
+static const ushort cmUnitBytes = 2201;
+static const ushort cmUnitKB = 2202;
+static const ushort cmUnitMB = 2203;
+static const ushort cmUnitGB = 2204;
+static const ushort cmUnitTB = 2205;
+static const ushort cmUnitBlocks = 2206;
+static const ushort cmSortUnsorted = 2300;
+static const ushort cmSortNameAsc = 2301;
+static const ushort cmSortNameDesc = 2302;
+static const ushort cmSortSizeDesc = 2303;
+static const ushort cmSortSizeAsc = 2304;
+static const ushort cmSortModifiedDesc = 2305;
+static const ushort cmSortModifiedAsc = 2306;
+
+namespace
+{
+std::array<TMenuItem *, 7> gUnitMenuItems{};
+}
+
+namespace
+{
+std::array<TMenuItem *, 7> gSortMenuItems{};
+}
+
+namespace
+{
+std::string directoryLabel(const DirectoryNode *node)
+{
+    std::string name;
+    if (node->parent == nullptr)
+        name = node->path.string();
+    else
+        name = node->path.filename().string();
+    if (name.empty())
+        name = node->path.string();
+
+    std::ostringstream out;
+    out << name << "  [" << formatSize(node->stats.totalSize, getCurrentUnit()) << "]";
+    out << "  " << node->stats.fileCount << " files";
+    if (node->stats.directoryCount > 0)
+        out << ", " << node->stats.directoryCount << " dirs";
+    return out.str();
+}
+
+std::string directorySortName(const DirectoryNode *node)
+{
+    if (!node)
+        return std::string();
+    std::string name = node->path.filename().string();
+    if (name.empty())
+        name = node->path.string();
+    return name;
+}
+
+std::vector<DirectoryNode *> orderedChildren(DirectoryNode *node)
+{
+    std::vector<DirectoryNode *> order;
+    if (!node)
+        return order;
+    order.reserve(node->children.size());
+    for (auto &child : node->children)
+        order.push_back(child.get());
+
+    auto key = getCurrentSortKey();
+    auto nameLess = [](DirectoryNode *a, DirectoryNode *b) {
+        return directorySortName(a) < directorySortName(b);
+    };
+    auto nameGreater = [](DirectoryNode *a, DirectoryNode *b) {
+        return directorySortName(a) > directorySortName(b);
+    };
+
+    switch (key)
+    {
+    case SortKey::Unsorted:
+        break;
+    case SortKey::NameAscending:
+        std::stable_sort(order.begin(), order.end(), nameLess);
+        break;
+    case SortKey::NameDescending:
+        std::stable_sort(order.begin(), order.end(), nameGreater);
+        break;
+    case SortKey::SizeDescending:
+        std::stable_sort(order.begin(), order.end(), [&](DirectoryNode *a, DirectoryNode *b) {
+            if (a->stats.totalSize == b->stats.totalSize)
+                return nameLess(a, b);
+            return a->stats.totalSize > b->stats.totalSize;
+        });
+        break;
+    case SortKey::SizeAscending:
+        std::stable_sort(order.begin(), order.end(), [&](DirectoryNode *a, DirectoryNode *b) {
+            if (a->stats.totalSize == b->stats.totalSize)
+                return nameLess(a, b);
+            return a->stats.totalSize < b->stats.totalSize;
+        });
+        break;
+    case SortKey::ModifiedDescending:
+        std::stable_sort(order.begin(), order.end(), [&](DirectoryNode *a, DirectoryNode *b) {
+            if (a->modifiedTime == b->modifiedTime)
+                return nameLess(a, b);
+            return a->modifiedTime > b->modifiedTime;
+        });
+        break;
+    case SortKey::ModifiedAscending:
+        std::stable_sort(order.begin(), order.end(), [&](DirectoryNode *a, DirectoryNode *b) {
+            if (a->modifiedTime == b->modifiedTime)
+                return nameLess(a, b);
+            return a->modifiedTime < b->modifiedTime;
+        });
+        break;
+    }
+
+    return order;
+}
+
+void applySortToFiles(std::vector<FileEntry> &entries)
+{
+    auto key = getCurrentSortKey();
+    auto nameLess = [](const FileEntry &a, const FileEntry &b) {
+        return a.displayPath < b.displayPath;
+    };
+    auto nameGreater = [](const FileEntry &a, const FileEntry &b) {
+        return a.displayPath > b.displayPath;
+    };
+
+    switch (key)
+    {
+    case SortKey::Unsorted:
+        break;
+    case SortKey::NameAscending:
+        std::stable_sort(entries.begin(), entries.end(), nameLess);
+        break;
+    case SortKey::NameDescending:
+        std::stable_sort(entries.begin(), entries.end(), nameGreater);
+        break;
+    case SortKey::SizeDescending:
+        std::stable_sort(entries.begin(), entries.end(), [&](const FileEntry &a, const FileEntry &b) {
+            if (a.size == b.size)
+                return nameLess(a, b);
+            return a.size > b.size;
+        });
+        break;
+    case SortKey::SizeAscending:
+        std::stable_sort(entries.begin(), entries.end(), [&](const FileEntry &a, const FileEntry &b) {
+            if (a.size == b.size)
+                return nameLess(a, b);
+            return a.size < b.size;
+        });
+        break;
+    case SortKey::ModifiedDescending:
+        std::stable_sort(entries.begin(), entries.end(), [&](const FileEntry &a, const FileEntry &b) {
+            if (a.modifiedTime == b.modifiedTime)
+                return nameLess(a, b);
+            return a.modifiedTime > b.modifiedTime;
+        });
+        break;
+    case SortKey::ModifiedAscending:
+        std::stable_sort(entries.begin(), entries.end(), [&](const FileEntry &a, const FileEntry &b) {
+            if (a.modifiedTime == b.modifiedTime)
+                return nameLess(a, b);
+            return a.modifiedTime < b.modifiedTime;
+        });
+        break;
+    }
+}
+
+} // namespace
+
+class DirTNode : public TNode
+{
+public:
+    DirectoryNode *dirNode;
+    DirTNode *parent = nullptr;
+    DirTNode(DirectoryNode *node, TStringView text, DirTNode *children = nullptr,
+             DirTNode *next = nullptr, Boolean exp = True) noexcept
+        : TNode(text, children, next, exp), dirNode(node) {}
+};
+
+class DirectoryWindow;
+
+class DirectoryOutline : public TOutline
+{
+public:
+    DirectoryOutline(TRect bounds, TScrollBar *h, TScrollBar *v, DirTNode *rootNode, DirectoryWindow &owner);
+
+    DirTNode *focusedNode();
+    void focusNode(DirTNode *target);
+    void syncExpanded();
+
+    virtual void handleEvent(TEvent &event) override;
+
+private:
+    DirectoryWindow &ownerWindow;
+};
+
+class FileListWindow;
+
+class FileListView : public TListViewer
+{
+public:
+    FileListView(const TRect &bounds, TScrollBar *h, TScrollBar *v,
+                 std::vector<FileEntry> &entries, std::size_t lineWidth);
+
+    virtual void getText(char *dest, short item, short maxLen) override;
+    void refreshMetrics();
+
+private:
+    std::vector<FileEntry> &files;
+    std::size_t maxLineWidth;
+    std::size_t nameWidth = 0;
+    std::size_t ownerWidth = 0;
+    std::size_t groupWidth = 0;
+    std::size_t sizeWidth = 0;
+    std::size_t createdWidth = 0;
+    std::size_t modifiedWidth = 0;
+
+    void computeWidths();
+};
+
+class FileListWindow : public TWindow
+{
+public:
+    FileListWindow(const std::string &title, std::vector<FileEntry> files, bool recursive, class DiskUsageApp &app);
+    ~FileListWindow();
+
+    void refreshUnits();
+    void refreshSort();
+
+private:
+    class DiskUsageApp &app;
+    std::vector<FileEntry> baseEntries;
+    std::vector<FileEntry> entries;
+    FileListView *listView = nullptr;
+    TScrollBar *hScroll = nullptr;
+    TScrollBar *vScroll = nullptr;
+    bool recursiveMode = false;
+
+    void buildView();
+};
+
+class DirectoryWindow : public TWindow
+{
+public:
+    DirectoryWindow(const std::filesystem::path &path, std::unique_ptr<DirectoryNode> rootNode, class DiskUsageApp &app);
+    ~DirectoryWindow();
+
+    DirectoryNode *focusedNode() const;
+    void refreshLabels();
+    void refreshSort();
+
+private:
+    class DiskUsageApp &app;
+    std::unique_ptr<DirectoryNode> root;
+    DirectoryOutline *outline = nullptr;
+    TScrollBar *hScroll = nullptr;
+    TScrollBar *vScroll = nullptr;
+    std::unordered_map<DirectoryNode *, DirTNode *> nodeMap;
+
+    DirTNode *buildNodes(DirectoryNode *node);
+    void buildOutline();
+    friend class DirectoryOutline;
+};
+
+class DiskUsageStatusLine : public TStatusLine
+{
+public:
+    DiskUsageStatusLine(TRect r)
+        : TStatusLine(r, *new TStatusDef(0, 0xFFFF, nullptr))
+    {
+        rebuild();
+    }
+
+private:
+    void rebuild()
+    {
+        disposeItems(items);
+        auto *open = new TStatusItem("~F2~ Open", kbF2, cmOpen);
+        auto *files = new TStatusItem("~F3~ Files", kbF3, cmViewFiles);
+        auto *recursive = new TStatusItem("~Shift-F3~ Files+Sub", kbShiftF3, cmViewFilesRecursive);
+        auto *quit = new TStatusItem("~Alt-X~ Quit", kbAltX, cmQuit);
+        open->next = files;
+        files->next = recursive;
+        recursive->next = quit;
+        items = open;
+        defs->items = items;
+        drawView();
+    }
+
+    void disposeItems(TStatusItem *item)
+    {
+        while (item)
+        {
+            TStatusItem *next = item->next;
+            delete item;
+            item = next;
+        }
+    }
+};
+
+class DiskUsageApp : public TApplication
+{
+public:
+    DiskUsageApp(int argc, char **argv);
+
+    virtual void handleEvent(TEvent &event) override;
+    virtual void idle() override;
+
+    static TMenuBar *initMenuBar(TRect r);
+    static TStatusLine *initStatusLine(TRect r);
+
+    void registerDirectoryWindow(DirectoryWindow *window);
+    void unregisterDirectoryWindow(DirectoryWindow *window);
+    void registerFileWindow(FileListWindow *window);
+    void unregisterFileWindow(FileListWindow *window);
+
+    void notifyUnitsChanged();
+    void notifySortChanged();
+
+private:
+    std::vector<DirectoryWindow *> directoryWindows;
+    std::vector<FileListWindow *> fileWindows;
+    std::unordered_map<SizeUnit, TMenuItem *> unitMenuItems;
+    std::unordered_map<SizeUnit, std::string> unitBaseLabels;
+    std::unordered_map<SortKey, TMenuItem *> sortMenuItems;
+    std::unordered_map<SortKey, std::string> sortBaseLabels;
+
+    void promptOpenDirectory();
+    void openDirectory(const std::filesystem::path &path);
+    void viewFiles(bool recursive);
+    DirectoryWindow *activeDirectoryWindow() const;
+    void updateUnitMenu();
+    void applyUnit(SizeUnit unit);
+    void updateSortMenu();
+    void applySortMode(SortKey key);
+};
+
+DirectoryOutline::DirectoryOutline(TRect bounds, TScrollBar *h, TScrollBar *v, DirTNode *rootNode, DirectoryWindow &owner)
+    : TOutline(bounds, h, v, rootNode), ownerWindow(owner)
+{
+}
+
+DirTNode *DirectoryOutline::focusedNode()
+{
+    return static_cast<DirTNode *>(getNode(foc));
+}
+
+void DirectoryOutline::focusNode(DirTNode *target)
+{
+    if (!target)
+        return;
+    struct Finder
+    {
+        DirTNode *target;
+        int index = 0;
+        int found = -1;
+    } finder{target};
+
+    forEach([](TOutlineViewer *, TNode *node, int, int pos, long, ushort, void *arg) -> Boolean {
+        auto &f = *static_cast<Finder *>(arg);
+        if (node == f.target)
+        {
+            f.found = f.index;
+            return True;
+        }
+        ++f.index;
+        return False;
+    }, &finder);
+
+    if (finder.found >= 0)
+    {
+        foc = finder.found;
+        scrollTo(0, finder.found);
+        drawView();
+        focused(finder.found);
+    }
+}
+
+void DirectoryOutline::syncExpanded()
+{
+    forEach([](TOutlineViewer *, TNode *node, int, int, long, ushort, void *arg) -> Boolean {
+        auto *dirNode = static_cast<DirTNode *>(node);
+        dirNode->expanded = dirNode->dirNode->expanded ? True : False;
+        return False;
+    }, nullptr);
+    update();
+}
+
+void DirectoryOutline::handleEvent(TEvent &event)
+{
+    if (event.what == evMouseDown && (event.mouse.buttons & mbLeftButton))
+    {
+        int clickX = event.mouse.where.x;
+        TOutline::handleEvent(event);
+        if (DirTNode *node = focusedNode())
+        {
+            int depth = 0;
+            for (DirectoryNode *p = node->dirNode; p && p->parent; p = p->parent)
+                ++depth;
+            int prefixWidth = depth * 2 + 2;
+            if (clickX < prefixWidth)
+            {
+                node->expanded = node->expanded ? False : True;
+                node->dirNode->expanded = node->expanded;
+                update();
+                drawView();
+            }
+        }
+        return;
+    }
+    if (event.what == evKeyDown)
+    {
+        DirTNode *node = focusedNode();
+        switch (event.keyDown.keyCode)
+        {
+        case kbLeft:
+            if (node)
+            {
+                if (node->expanded && node->childList)
+                {
+                    node->expanded = False;
+                    node->dirNode->expanded = false;
+                    update();
+                    drawView();
+                }
+                else if (node->parent)
+                    focusNode(static_cast<DirTNode *>(node->parent));
+            }
+            clearEvent(event);
+            return;
+        case kbRight:
+            if (node)
+            {
+                if (!node->expanded && node->childList)
+                {
+                    node->expanded = True;
+                    node->dirNode->expanded = true;
+                    update();
+                    drawView();
+                }
+                else if (node->childList)
+                    focusNode(static_cast<DirTNode *>(node->childList));
+            }
+            clearEvent(event);
+            return;
+        default:
+            break;
+        }
+    }
+    TOutline::handleEvent(event);
+}
+
+FileListView::FileListView(const TRect &bounds, TScrollBar *h, TScrollBar *v, std::vector<FileEntry> &entries,
+                           std::size_t lineWidth)
+    : TListViewer(bounds, static_cast<ushort>(lineWidth), h, v), files(entries), maxLineWidth(lineWidth)
+{
+    range = static_cast<short>(entries.size());
+    computeWidths();
+}
+
+void FileListView::computeWidths()
+{
+    nameWidth = 0;
+    ownerWidth = 0;
+    groupWidth = 0;
+    sizeWidth = 0;
+    createdWidth = 0;
+    modifiedWidth = 0;
+
+    for (const auto &entry : files)
+    {
+        nameWidth = std::max(nameWidth, entry.displayPath.size());
+        ownerWidth = std::max(ownerWidth, entry.owner.size());
+        groupWidth = std::max(groupWidth, entry.group.size());
+        createdWidth = std::max(createdWidth, entry.created.size());
+        modifiedWidth = std::max(modifiedWidth, entry.modified.size());
+        sizeWidth = std::max(sizeWidth, formatSize(entry.size, getCurrentUnit()).size());
+    }
+    if (createdWidth == 0)
+        createdWidth = std::string("YYYY-MM-DD HH:MM").size();
+    if (modifiedWidth == 0)
+        modifiedWidth = std::string("YYYY-MM-DD HH:MM").size();
+    if (sizeWidth == 0)
+        sizeWidth = std::string("0 B").size();
+}
+
+void FileListView::refreshMetrics()
+{
+    computeWidths();
+    sizeWidth = std::max<size_t>(sizeWidth, std::string("0 B").size());
+    maxLineWidth = nameWidth + ownerWidth + groupWidth + sizeWidth + createdWidth + modifiedWidth + 12;
+    numCols = static_cast<short>(maxLineWidth);
+    drawView();
+}
+
+void FileListView::getText(char *dest, short item, short maxLen)
+{
+    if (item < 0 || static_cast<std::size_t>(item) >= files.size())
+    {
+        *dest = '\0';
+        return;
+    }
+
+    const FileEntry &entry = files[item];
+    std::ostringstream line;
+    line << entry.displayPath;
+    if (entry.displayPath.size() < nameWidth)
+        line << std::string(nameWidth - entry.displayPath.size(), ' ');
+    line << "  " << entry.owner;
+    if (entry.owner.size() < ownerWidth)
+        line << std::string(ownerWidth - entry.owner.size(), ' ');
+    line << ':';
+    line << entry.group;
+    if (entry.group.size() < groupWidth)
+        line << std::string(groupWidth - entry.group.size(), ' ');
+    std::string sizeStr = formatSize(entry.size, getCurrentUnit());
+    line << "  " << sizeStr;
+    if (sizeStr.size() < sizeWidth)
+        line << std::string(sizeWidth - sizeStr.size(), ' ');
+    line << entry.created;
+    if (entry.created.size() < createdWidth)
+        line << std::string(createdWidth - entry.created.size(), ' ');
+    line << "  " << entry.modified;
+
+    std::string text = line.str();
+    if (text.size() >= static_cast<std::size_t>(maxLen))
+        text.resize(maxLen - 1);
+    std::snprintf(dest, maxLen, "%s", text.c_str());
+}
+
+FileListWindow::FileListWindow(const std::string &title, std::vector<FileEntry> files, bool recursive, DiskUsageApp &appRef)
+    : TWindowInit(&TWindow::initFrame),
+      TWindow(TRect(0, 0, 78, 20), title.c_str(), wnNoNumber),
+      app(appRef), baseEntries(std::move(files)), recursiveMode(recursive)
+{
+    flags |= wfGrow;
+    growMode = gfGrowHiX | gfGrowHiY;
+    refreshSort();
+    buildView();
+    app.registerFileWindow(this);
+}
+
+FileListWindow::~FileListWindow()
+{
+    app.unregisterFileWindow(this);
+}
+
+void FileListWindow::buildView()
+{
+    TRect r = getExtent();
+    r.grow(-1, -1);
+    if (r.b.x <= r.a.x + 2 || r.b.y <= r.a.y + 2)
+        r = TRect(0, 0, 76, 18);
+
+    vScroll = new TScrollBar(TRect(r.b.x - 1, r.a.y, r.b.x, r.b.y));
+    vScroll->growMode = gfGrowHiY;
+    hScroll = new TScrollBar(TRect(r.a.x, r.b.y - 1, r.b.x - 1, r.b.y));
+    hScroll->growMode = gfGrowHiX;
+
+    std::size_t lineWidth = 0;
+    for (const auto &entry : entries)
+    {
+        std::string sizeStr = formatSize(entry.size, getCurrentUnit());
+        std::size_t width = entry.displayPath.size() + entry.owner.size() + entry.group.size() +
+                            sizeStr.size() + entry.created.size() + entry.modified.size() + 12;
+        lineWidth = std::max(lineWidth, width);
+    }
+    if (lineWidth == 0)
+        lineWidth = 60;
+
+    auto *view = new FileListView(TRect(r.a.x, r.a.y, r.b.x - 1, r.b.y - 1), hScroll, vScroll, entries, lineWidth);
+    view->growMode = gfGrowHiX | gfGrowHiY;
+
+    insert(vScroll);
+    insert(hScroll);
+    insert(view);
+    listView = view;
+    view->drawView();
+    hScroll->drawView();
+    vScroll->drawView();
+}
+
+void FileListWindow::refreshUnits()
+{
+    if (listView)
+    {
+        listView->refreshMetrics();
+        listView->drawView();
+    }
+}
+
+void FileListWindow::refreshSort()
+{
+    entries = baseEntries;
+    applySortToFiles(entries);
+    if (listView)
+    {
+        listView->setRange(static_cast<short>(entries.size()));
+        listView->refreshMetrics();
+        listView->drawView();
+    }
+    if (hScroll)
+        hScroll->drawView();
+    if (vScroll)
+        vScroll->drawView();
+}
+
+DirectoryWindow::DirectoryWindow(const std::filesystem::path &path, std::unique_ptr<DirectoryNode> rootNode, DiskUsageApp &appRef)
+    : TWindowInit(&TWindow::initFrame),
+      TWindow(TRect(0, 0, 78, 20), path.filename().empty() ? path.string().c_str() : path.filename().string().c_str(), wnNoNumber),
+      app(appRef), root(std::move(rootNode))
+{
+    flags |= wfGrow;
+    growMode = gfGrowHiX | gfGrowHiY;
+    buildOutline();
+    app.registerDirectoryWindow(this);
+}
+
+DirectoryWindow::~DirectoryWindow()
+{
+    app.unregisterDirectoryWindow(this);
+}
+
+DirTNode *DirectoryWindow::buildNodes(DirectoryNode *node)
+{
+    DirTNode *firstChild = nullptr;
+    DirTNode *prev = nullptr;
+    std::vector<DirTNode *> created;
+    for (auto *childDir : orderedChildren(node))
+    {
+        DirTNode *childNode = buildNodes(childDir);
+        created.push_back(childNode);
+        if (!firstChild)
+            firstChild = childNode;
+        else
+            prev->next = childNode;
+        prev = childNode;
+    }
+    std::string label = directoryLabel(node);
+    auto *current = new DirTNode(node, label.c_str(), firstChild, nullptr, node->expanded ? True : False);
+    for (auto *childNode : created)
+        childNode->parent = current;
+    nodeMap[node] = current;
+    return current;
+}
+
+void DirectoryWindow::buildOutline()
+{
+    nodeMap.clear();
+    DirTNode *rootNode = buildNodes(root.get());
+    rootNode->expanded = True;
+
+    TRect r = getExtent();
+    r.grow(-1, -1);
+    if (r.b.x <= r.a.x + 2 || r.b.y <= r.a.y + 2)
+        r = TRect(0, 0, 76, 18);
+
+    vScroll = new TScrollBar(TRect(r.b.x - 1, r.a.y, r.b.x, r.b.y));
+    vScroll->growMode = gfGrowHiY;
+    hScroll = new TScrollBar(TRect(r.a.x, r.b.y - 1, r.b.x - 1, r.b.y));
+    hScroll->growMode = gfGrowHiX;
+
+    auto *view = new DirectoryOutline(TRect(r.a.x, r.a.y, r.b.x - 1, r.b.y - 1), hScroll, vScroll, rootNode, *this);
+    view->growMode = gfGrowHiX | gfGrowHiY;
+    insert(vScroll);
+    insert(hScroll);
+    insert(view);
+    outline = view;
+    outline->update();
+    outline->drawView();
+}
+
+DirectoryNode *DirectoryWindow::focusedNode() const
+{
+    if (!outline)
+        return nullptr;
+    if (DirTNode *node = outline->focusedNode())
+        return node->dirNode;
+    return nullptr;
+}
+
+void DirectoryWindow::refreshLabels()
+{
+    for (auto &pair : nodeMap)
+    {
+        DirectoryNode *node = pair.first;
+        DirTNode *tnode = pair.second;
+        std::string label = directoryLabel(node);
+        delete[] const_cast<char *>(tnode->text);
+        tnode->text = newStr(label.c_str());
+    }
+    if (outline)
+    {
+        outline->update();
+        outline->drawView();
+    }
+}
+
+void DirectoryWindow::refreshSort()
+{
+    if (!root)
+        return;
+
+    DirectoryNode *focused = focusedNode();
+
+    auto reorder = [&](auto &&self, DirectoryNode *dir) -> void {
+        auto mapIt = nodeMap.find(dir);
+        if (mapIt == nodeMap.end())
+            return;
+        DirTNode *tnode = mapIt->second;
+        std::vector<DirectoryNode *> order = orderedChildren(dir);
+        DirTNode *firstChild = nullptr;
+        DirTNode *prev = nullptr;
+        for (DirectoryNode *childDir : order)
+        {
+            auto childIt = nodeMap.find(childDir);
+            if (childIt == nodeMap.end())
+                continue;
+            DirTNode *childNode = childIt->second;
+            childNode->parent = tnode;
+            childNode->next = nullptr;
+            if (!firstChild)
+                firstChild = childNode;
+            else
+                prev->next = childNode;
+            prev = childNode;
+        }
+        if (tnode)
+            tnode->childList = firstChild;
+        for (DirectoryNode *childDir : order)
+            self(self, childDir);
+    };
+
+    reorder(reorder, root.get());
+
+    if (outline)
+    {
+        outline->syncExpanded();
+        outline->update();
+        outline->drawView();
+        if (focused)
+        {
+            auto it = nodeMap.find(focused);
+            if (it != nodeMap.end())
+                outline->focusNode(it->second);
+        }
+    }
+}
+
+DiskUsageApp::DiskUsageApp(int argc, char **argv)
+    : TProgInit(&DiskUsageApp::initStatusLine, &DiskUsageApp::initMenuBar, &TApplication::initDeskTop),
+      TApplication()
+{
+    unitBaseLabels = {{SizeUnit::Auto, "Auto"},
+                      {SizeUnit::Bytes, "Bytes"},
+                      {SizeUnit::Kilobytes, "Kilobytes"},
+                      {SizeUnit::Megabytes, "Megabytes"},
+                      {SizeUnit::Gigabytes, "Gigabytes"},
+                      {SizeUnit::Terabytes, "Terabytes"},
+                      {SizeUnit::Blocks, "Blocks"}};
+    sortBaseLabels = {{SortKey::Unsorted, "Unsorted"},
+                      {SortKey::NameAscending, "Name (A→Z)"},
+                      {SortKey::NameDescending, "Name (Z→A)"},
+                      {SortKey::SizeDescending, "Size (Largest)"},
+                      {SortKey::SizeAscending, "Size (Smallest)"},
+                      {SortKey::ModifiedDescending, "Modified (Newest)"},
+                      {SortKey::ModifiedAscending, "Modified (Oldest)"}};
+    std::array<std::pair<SizeUnit, int>, 7> unitOrder = {{
+        {SizeUnit::Auto, 0},
+        {SizeUnit::Bytes, 1},
+        {SizeUnit::Kilobytes, 2},
+        {SizeUnit::Megabytes, 3},
+        {SizeUnit::Gigabytes, 4},
+        {SizeUnit::Terabytes, 5},
+        {SizeUnit::Blocks, 6}}};
+    for (const auto &[unit, index] : unitOrder)
+    {
+        if (index >= 0 && index < static_cast<int>(gUnitMenuItems.size()) && gUnitMenuItems[index])
+            unitMenuItems[unit] = gUnitMenuItems[index];
+    }
+    updateUnitMenu();
+
+    std::array<std::pair<SortKey, int>, 7> sortOrder = {{
+        {SortKey::Unsorted, 0},
+        {SortKey::NameAscending, 1},
+        {SortKey::NameDescending, 2},
+        {SortKey::SizeDescending, 3},
+        {SortKey::SizeAscending, 4},
+        {SortKey::ModifiedDescending, 5},
+        {SortKey::ModifiedAscending, 6}}};
+    for (const auto &[key, index] : sortOrder)
+    {
+        if (index >= 0 && index < static_cast<int>(gSortMenuItems.size()) && gSortMenuItems[index])
+            sortMenuItems[key] = gSortMenuItems[index];
+    }
+    updateSortMenu();
+
+    for (int i = 1; i < argc; ++i)
+        openDirectory(argv[i]);
+}
+
+void DiskUsageApp::handleEvent(TEvent &event)
+{
+    TApplication::handleEvent(event);
+    if (event.what == evCommand)
+    {
+        switch (event.message.command)
+        {
+        case cmOpen:
+            promptOpenDirectory();
+            break;
+        case cmViewFiles:
+            viewFiles(false);
+            break;
+        case cmViewFilesRecursive:
+            viewFiles(true);
+            break;
+        case cmUnitAuto:
+            applyUnit(SizeUnit::Auto);
+            break;
+        case cmUnitBytes:
+            applyUnit(SizeUnit::Bytes);
+            break;
+        case cmUnitKB:
+            applyUnit(SizeUnit::Kilobytes);
+            break;
+        case cmUnitMB:
+            applyUnit(SizeUnit::Megabytes);
+            break;
+        case cmUnitGB:
+            applyUnit(SizeUnit::Gigabytes);
+            break;
+        case cmUnitTB:
+            applyUnit(SizeUnit::Terabytes);
+            break;
+        case cmUnitBlocks:
+            applyUnit(SizeUnit::Blocks);
+            break;
+        case cmSortUnsorted:
+            applySortMode(SortKey::Unsorted);
+            break;
+        case cmSortNameAsc:
+            applySortMode(SortKey::NameAscending);
+            break;
+        case cmSortNameDesc:
+            applySortMode(SortKey::NameDescending);
+            break;
+        case cmSortSizeDesc:
+            applySortMode(SortKey::SizeDescending);
+            break;
+        case cmSortSizeAsc:
+            applySortMode(SortKey::SizeAscending);
+            break;
+        case cmSortModifiedDesc:
+            applySortMode(SortKey::ModifiedDescending);
+            break;
+        case cmSortModifiedAsc:
+            applySortMode(SortKey::ModifiedAscending);
+            break;
+        case cmAbout:
+        {
+            std::string msg = std::string("ck-du ") + CK_DU_VERSION +
+                              "\nDeveloper: " + kDeveloperName;
+            messageBox(msg.c_str(), mfInformation | mfOKButton);
+            break;
+        }
+        default:
+            return;
+        }
+        clearEvent(event);
+    }
+}
+
+void DiskUsageApp::idle()
+{
+    TApplication::idle();
+}
+
+TMenuBar *DiskUsageApp::initMenuBar(TRect r)
+{
+    r.b.y = r.a.y + 1;
+    auto *unitAuto = new TMenuItem("Auto", cmUnitAuto, kbNoKey, hcNoContext);
+    auto *unitBytes = new TMenuItem("Bytes", cmUnitBytes, kbNoKey, hcNoContext);
+    auto *unitKB = new TMenuItem("Kilobytes", cmUnitKB, kbNoKey, hcNoContext);
+    auto *unitMB = new TMenuItem("Megabytes", cmUnitMB, kbNoKey, hcNoContext);
+    auto *unitGB = new TMenuItem("Gigabytes", cmUnitGB, kbNoKey, hcNoContext);
+    auto *unitTB = new TMenuItem("Terabytes", cmUnitTB, kbNoKey, hcNoContext);
+    auto *unitBlocks = new TMenuItem("Blocks", cmUnitBlocks, kbNoKey, hcNoContext);
+    gUnitMenuItems = {unitAuto, unitBytes, unitKB, unitMB, unitGB, unitTB, unitBlocks};
+    auto *sortUnsorted = new TMenuItem("Unsorted", cmSortUnsorted, kbNoKey, hcNoContext);
+    auto *sortNameAsc = new TMenuItem("Name (A→Z)", cmSortNameAsc, kbNoKey, hcNoContext);
+    auto *sortNameDesc = new TMenuItem("Name (Z→A)", cmSortNameDesc, kbNoKey, hcNoContext);
+    auto *sortSizeDesc = new TMenuItem("Size (Largest)", cmSortSizeDesc, kbNoKey, hcNoContext);
+    auto *sortSizeAsc = new TMenuItem("Size (Smallest)", cmSortSizeAsc, kbNoKey, hcNoContext);
+    auto *sortModifiedDesc = new TMenuItem("Modified (Newest)", cmSortModifiedDesc, kbNoKey, hcNoContext);
+    auto *sortModifiedAsc = new TMenuItem("Modified (Oldest)", cmSortModifiedAsc, kbNoKey, hcNoContext);
+    gSortMenuItems = {sortUnsorted, sortNameAsc, sortNameDesc, sortSizeDesc, sortSizeAsc, sortModifiedDesc, sortModifiedAsc};
+    return new TMenuBar(r,
+                        *new TSubMenu("~F~ile", hcNoContext) +
+                            *new TMenuItem("~O~pen Directory", cmOpen, kbF2, hcOpen, "F2") +
+                            *new TMenuItem("~C~lose", cmClose, kbF4, hcClose, "F4") +
+                            newLine() +
+                            *new TMenuItem("E~x~it", cmQuit, kbAltX, hcExit, "Alt-X") +
+                        *new TSubMenu("~A~ctions", hcNoContext) +
+                            *new TMenuItem("~V~iew Files", cmViewFiles, kbF3, hcNoContext, "F3") +
+                            *new TMenuItem("Files (~R~ecursive)", cmViewFilesRecursive, kbShiftF3, hcNoContext, "Shift-F3") +
+                        *new TSubMenu("~S~ort", hcNoContext) +
+                            *sortUnsorted +
+                            *sortNameAsc +
+                            *sortNameDesc +
+                            *sortSizeDesc +
+                            *sortSizeAsc +
+                            *sortModifiedDesc +
+                            *sortModifiedAsc +
+                        *new TSubMenu("~U~nits", hcNoContext) +
+                            *unitAuto +
+                            *unitBytes +
+                            *unitKB +
+                            *unitMB +
+                            *unitGB +
+                            *unitTB +
+                            *unitBlocks +
+                        *new TSubMenu("~H~elp", hcNoContext) +
+                            *new TMenuItem("~A~bout", cmAbout, kbF1, hcNoContext, "F1"));
+}
+
+TStatusLine *DiskUsageApp::initStatusLine(TRect r)
+{
+    r.a.y = r.b.y - 1;
+    return new DiskUsageStatusLine(r);
+}
+
+void DiskUsageApp::promptOpenDirectory()
+{
+    struct DialogData
+    {
+        char path[PATH_MAX];
+    } data{};
+
+    std::string current = std::filesystem::current_path().string();
+    std::snprintf(data.path, sizeof(data.path), "%s", current.c_str());
+
+    TDialog *d = new TDialog(TRect(0, 0, 60, 10), "Open Directory");
+    d->options |= ofCentered;
+    auto *input = new TInputLine(TRect(3, 3, 55, 4), sizeof(data.path) - 1);
+    d->insert(input);
+    d->insert(new TLabel(TRect(2, 2, 20, 3), "~P~ath:", input));
+    d->insert(new TButton(TRect(15, 6, 25, 8), "O~K~", cmOK, bfDefault));
+    d->insert(new TButton(TRect(27, 6, 37, 8), "Cancel", cmCancel, bfNormal));
+
+    if (executeDialog(d, &data) != cmCancel)
+        openDirectory(data.path);
+}
+
+void DiskUsageApp::openDirectory(const std::filesystem::path &path)
+{
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec) || !std::filesystem::is_directory(path, ec))
+    {
+        messageBox("Path is not a directory", mfError | mfOKButton);
+        return;
+    }
+
+    auto tree = buildDirectoryTree(path);
+    if (!tree)
+    {
+        messageBox("Failed to read directory", mfError | mfOKButton);
+        return;
+    }
+
+    DirectoryWindow *win = new DirectoryWindow(path, std::move(tree), *this);
+    deskTop->insert(win);
+    win->drawView();
+}
+
+void DiskUsageApp::viewFiles(bool recursive)
+{
+    DirectoryWindow *window = activeDirectoryWindow();
+    if (!window)
+    {
+        messageBox("No directory window active", mfError | mfOKButton);
+        return;
+    }
+    DirectoryNode *node = window->focusedNode();
+    if (!node)
+    {
+        messageBox("No directory selected", mfError | mfOKButton);
+        return;
+    }
+
+    std::vector<FileEntry> files = listFiles(node->path, recursive);
+    std::string title = node->path.filename().empty() ? node->path.string() : node->path.filename().string();
+    if (title.empty())
+        title = node->path.string();
+    title += recursive ? " (files + subdirs)" : " (files)";
+
+    auto *win = new FileListWindow(title, std::move(files), recursive, *this);
+    deskTop->insert(win);
+    win->drawView();
+}
+
+DirectoryWindow *DiskUsageApp::activeDirectoryWindow() const
+{
+    if (!deskTop)
+        return nullptr;
+    TView *current = deskTop->current;
+    while (current && current->owner != deskTop)
+        current = current->owner;
+    return dynamic_cast<DirectoryWindow *>(current);
+}
+
+void DiskUsageApp::registerDirectoryWindow(DirectoryWindow *window)
+{
+    directoryWindows.push_back(window);
+}
+
+void DiskUsageApp::unregisterDirectoryWindow(DirectoryWindow *window)
+{
+    directoryWindows.erase(std::remove(directoryWindows.begin(), directoryWindows.end(), window), directoryWindows.end());
+}
+
+void DiskUsageApp::registerFileWindow(FileListWindow *window)
+{
+    fileWindows.push_back(window);
+}
+
+void DiskUsageApp::unregisterFileWindow(FileListWindow *window)
+{
+    fileWindows.erase(std::remove(fileWindows.begin(), fileWindows.end(), window), fileWindows.end());
+}
+
+void DiskUsageApp::notifyUnitsChanged()
+{
+    for (auto *win : directoryWindows)
+        if (win)
+            win->refreshLabels();
+    for (auto *win : fileWindows)
+        if (win)
+            win->refreshUnits();
+}
+
+void DiskUsageApp::notifySortChanged()
+{
+    for (auto *win : directoryWindows)
+        if (win)
+            win->refreshSort();
+    for (auto *win : fileWindows)
+        if (win)
+            win->refreshSort();
+}
+
+void DiskUsageApp::updateUnitMenu()
+{
+    SizeUnit current = getCurrentUnit();
+    for (auto &pair : unitMenuItems)
+    {
+        SizeUnit unit = pair.first;
+        TMenuItem *item = pair.second;
+        if (!item)
+            continue;
+        auto baseIt = unitBaseLabels.find(unit);
+        std::string base = (baseIt != unitBaseLabels.end()) ? baseIt->second : unitName(unit);
+        std::string label = std::string(unit == current ? "● " : "  ") + base;
+        delete[] const_cast<char *>(item->name);
+        item->name = newStr(label.c_str());
+    }
+    if (menuBar)
+        menuBar->drawView();
+}
+
+void DiskUsageApp::applyUnit(SizeUnit unit)
+{
+    if (getCurrentUnit() == unit)
+        return;
+    setCurrentUnit(unit);
+    updateUnitMenu();
+    notifyUnitsChanged();
+}
+
+void DiskUsageApp::updateSortMenu()
+{
+    SortKey current = getCurrentSortKey();
+    for (auto &pair : sortMenuItems)
+    {
+        SortKey key = pair.first;
+        TMenuItem *item = pair.second;
+        if (!item)
+            continue;
+        auto baseIt = sortBaseLabels.find(key);
+        std::string base = (baseIt != sortBaseLabels.end()) ? baseIt->second : sortKeyName(key);
+        std::string label = std::string(key == current ? "● " : "  ") + base;
+        delete[] const_cast<char *>(item->name);
+        item->name = newStr(label.c_str());
+    }
+    if (menuBar)
+        menuBar->drawView();
+}
+
+void DiskUsageApp::applySortMode(SortKey key)
+{
+    if (getCurrentSortKey() == key)
+        return;
+    setCurrentSortKey(key);
+    updateSortMenu();
+    notifySortChanged();
+}
+
+int main(int argc, char **argv)
+{
+    DiskUsageApp app(argc, argv);
+    app.run();
+    return 0;
+}
+

--- a/src/tools/ck-du/src/disk_usage_core.cpp
+++ b/src/tools/ck-du/src/disk_usage_core.cpp
@@ -1,0 +1,371 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "disk_usage_core.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <fcntl.h>
+#include <grp.h>
+#include <iomanip>
+#include <pwd.h>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <system_error>
+#include <unistd.h>
+
+namespace ck::du
+{
+namespace
+{
+namespace fs = std::filesystem;
+
+SizeUnit gCurrentUnit = SizeUnit::Auto;
+SortKey gCurrentSortKey = SortKey::Unsorted;
+
+std::string formatTimePoint(const std::chrono::system_clock::time_point &tp)
+{
+    if (tp.time_since_epoch().count() == 0)
+        return "-";
+
+    std::time_t tt = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm{};
+#if defined(_WIN32)
+    std::tm *tmp = std::localtime(&tt);
+    if (!tmp)
+        return "-";
+    tm = *tmp;
+#else
+    if (!localtime_r(&tt, &tm))
+        return "-";
+#endif
+    std::ostringstream out;
+    out << std::put_time(&tm, "%Y-%m-%d %H:%M");
+    return out.str();
+}
+
+std::string ownerName(uid_t uid)
+{
+    if (passwd *pw = getpwuid(uid))
+        return pw->pw_name;
+    return std::to_string(uid);
+}
+
+std::string groupName(gid_t gid)
+{
+    if (group *gr = getgrgid(gid))
+        return gr->gr_name;
+    return std::to_string(gid);
+}
+
+DirectoryStats populateNode(DirectoryNode &node, const fs::path &path)
+{
+    node.path = path;
+    DirectoryStats stats{};
+    std::error_code ec;
+
+    struct stat sb;
+    if (stat(path.c_str(), &sb) == 0)
+        node.modifiedTime = std::chrono::system_clock::from_time_t(sb.st_mtime);
+    else
+        node.modifiedTime = std::chrono::system_clock::time_point{};
+
+    fs::directory_iterator endIter;
+    fs::directory_iterator it(path, fs::directory_options::skip_permission_denied, ec);
+    if (ec)
+    {
+        node.stats = stats;
+        return stats;
+    }
+
+    for (; it != endIter; it.increment(ec))
+    {
+        if (ec)
+        {
+            ec.clear();
+            continue;
+        }
+
+        const fs::directory_entry &entry = *it;
+        std::error_code entryEc;
+        const fs::path &entryPath = entry.path();
+
+        if (entry.is_symlink(entryEc))
+        {
+            if (!entryEc && entry.is_directory(entryEc))
+                continue;
+        }
+
+        if (!entryEc && entry.is_directory(entryEc))
+        {
+            auto child = std::make_unique<DirectoryNode>();
+            child->parent = &node;
+            child->expanded = false;
+            DirectoryStats childStats = populateNode(*child, entryPath);
+            child->stats = childStats;
+            stats.totalSize += childStats.totalSize;
+            stats.fileCount += childStats.fileCount;
+            stats.directoryCount += childStats.directoryCount + 1;
+            node.children.push_back(std::move(child));
+        }
+        else
+        {
+            std::uintmax_t fileSize = 0;
+            if (!entryEc && entry.is_regular_file(entryEc))
+                fileSize = entry.file_size(entryEc);
+            stats.totalSize += fileSize;
+            ++stats.fileCount;
+        }
+    }
+
+    node.stats = stats;
+    return stats;
+}
+
+FileEntry makeFileEntry(const fs::path &path, const fs::path &base)
+{
+    FileEntry entry;
+    entry.path = path;
+    entry.displayPath = path.lexically_relative(base).string();
+    if (entry.displayPath.empty())
+        entry.displayPath = path.filename().string();
+
+    struct stat sb;
+    if (stat(path.c_str(), &sb) == 0)
+    {
+        entry.size = static_cast<std::uintmax_t>(sb.st_size);
+        entry.owner = ownerName(sb.st_uid);
+        entry.group = groupName(sb.st_gid);
+        entry.modifiedTime = std::chrono::system_clock::from_time_t(sb.st_mtime);
+        entry.modified = formatTimePoint(entry.modifiedTime);
+#if defined(__linux__) && defined(STATX_BTIME)
+        struct statx stx;
+        if (statx(AT_FDCWD, path.c_str(), AT_STATX_SYNC_AS_STAT, STATX_BTIME, &stx) == 0 &&
+            (stx.stx_mask & STATX_BTIME))
+        {
+            entry.createdTime =
+                std::chrono::system_clock::from_time_t(stx.stx_btime.tv_sec) +
+                std::chrono::nanoseconds(stx.stx_btime.tv_nsec);
+            entry.created = formatTimePoint(entry.createdTime);
+        }
+        else
+#endif
+        {
+            entry.createdTime = std::chrono::system_clock::from_time_t(sb.st_ctime);
+            entry.created = formatTimePoint(entry.createdTime);
+        }
+    }
+    else
+    {
+        entry.size = 0;
+        entry.owner = "?";
+        entry.group = "?";
+        entry.created = "-";
+        entry.modified = "-";
+        entry.createdTime = std::chrono::system_clock::time_point{};
+        entry.modifiedTime = std::chrono::system_clock::time_point{};
+    }
+
+    if (entry.displayPath.empty())
+        entry.displayPath = path.filename().string();
+    if (entry.displayPath.empty())
+        entry.displayPath = path.string();
+
+    return entry;
+}
+
+} // namespace
+
+std::unique_ptr<DirectoryNode> buildDirectoryTree(const std::filesystem::path &rootPath)
+{
+    auto root = std::make_unique<DirectoryNode>();
+    root->parent = nullptr;
+    root->expanded = true;
+
+    DirectoryStats stats = populateNode(*root, fs::absolute(rootPath));
+    root->stats = stats;
+    return root;
+}
+
+std::vector<FileEntry> listFiles(const std::filesystem::path &directory, bool recursive)
+{
+    std::vector<FileEntry> files;
+    const fs::path base = fs::absolute(directory);
+    std::error_code ec;
+
+    if (recursive)
+    {
+        fs::recursive_directory_iterator it(base, fs::directory_options::skip_permission_denied, ec);
+        fs::recursive_directory_iterator end;
+        if (ec)
+            return files;
+
+        for (; it != end; it.increment(ec))
+        {
+            if (ec)
+            {
+                ec.clear();
+                continue;
+            }
+
+            const fs::directory_entry &entry = *it;
+            std::error_code entryEc;
+            if (entry.is_directory(entryEc) && !entryEc)
+                continue;
+            if (!entryEc && entry.is_regular_file(entryEc))
+                files.push_back(makeFileEntry(entry.path(), base));
+        }
+    }
+    else
+    {
+        fs::directory_iterator it(base, fs::directory_options::skip_permission_denied, ec);
+        fs::directory_iterator end;
+        if (ec)
+            return files;
+
+        for (; it != end; it.increment(ec))
+        {
+            if (ec)
+            {
+                ec.clear();
+                continue;
+            }
+
+            const fs::directory_entry &entry = *it;
+            std::error_code entryEc;
+            if (!entryEc && entry.is_regular_file(entryEc))
+                files.push_back(makeFileEntry(entry.path(), base));
+        }
+    }
+
+    return files;
+}
+
+SizeUnit getCurrentUnit() noexcept
+{
+    return gCurrentUnit;
+}
+
+void setCurrentUnit(SizeUnit unit) noexcept
+{
+    gCurrentUnit = unit;
+}
+
+const char *unitName(SizeUnit unit) noexcept
+{
+    switch (unit)
+    {
+    case SizeUnit::Auto:
+        return "Auto";
+    case SizeUnit::Bytes:
+        return "Bytes";
+    case SizeUnit::Kilobytes:
+        return "Kilobytes";
+    case SizeUnit::Megabytes:
+        return "Megabytes";
+    case SizeUnit::Gigabytes:
+        return "Gigabytes";
+    case SizeUnit::Terabytes:
+        return "Terabytes";
+    case SizeUnit::Blocks:
+        return "Blocks";
+    }
+    return "";
+}
+
+std::string formatSize(std::uintmax_t bytes, SizeUnit unit)
+{
+    auto renderValue = [](double value) {
+        std::ostringstream out;
+        if (value >= 100)
+            out << std::fixed << std::setprecision(0);
+        else if (value >= 10)
+            out << std::fixed << std::setprecision(1);
+        else
+            out << std::fixed << std::setprecision(2);
+        out << value;
+        return out.str();
+    };
+
+    SizeUnit effectiveUnit = unit;
+    if (unit == SizeUnit::Auto)
+    {
+        if (bytes >= (1ULL << 40))
+            effectiveUnit = SizeUnit::Terabytes;
+        else if (bytes >= (1ULL << 30))
+            effectiveUnit = SizeUnit::Gigabytes;
+        else if (bytes >= (1ULL << 20))
+            effectiveUnit = SizeUnit::Megabytes;
+        else if (bytes >= (1ULL << 10))
+            effectiveUnit = SizeUnit::Kilobytes;
+        else
+            effectiveUnit = SizeUnit::Bytes;
+    }
+
+    switch (effectiveUnit)
+    {
+    case SizeUnit::Auto:
+        break;
+    case SizeUnit::Bytes:
+    {
+        std::ostringstream out;
+        out << bytes << " B";
+        return out.str();
+    }
+    case SizeUnit::Kilobytes:
+        return renderValue(static_cast<double>(bytes) / 1024.0) + " KB";
+    case SizeUnit::Megabytes:
+        return renderValue(static_cast<double>(bytes) / (1024.0 * 1024.0)) + " MB";
+    case SizeUnit::Gigabytes:
+        return renderValue(static_cast<double>(bytes) / (1024.0 * 1024.0 * 1024.0)) + " GB";
+    case SizeUnit::Terabytes:
+        return renderValue(static_cast<double>(bytes) / (1024.0 * 1024.0 * 1024.0 * 1024.0)) + " TB";
+    case SizeUnit::Blocks:
+    {
+        std::uintmax_t blocks = (bytes + 511) / 512;
+        std::ostringstream out;
+        out << blocks << " blocks";
+        return out.str();
+    }
+    }
+    return std::to_string(bytes) + " B";
+}
+
+SortKey getCurrentSortKey() noexcept
+{
+    return gCurrentSortKey;
+}
+
+void setCurrentSortKey(SortKey key) noexcept
+{
+    gCurrentSortKey = key;
+}
+
+const char *sortKeyName(SortKey key) noexcept
+{
+    switch (key)
+    {
+    case SortKey::Unsorted:
+        return "Unsorted";
+    case SortKey::NameAscending:
+        return "Name (A→Z)";
+    case SortKey::NameDescending:
+        return "Name (Z→A)";
+    case SortKey::SizeDescending:
+        return "Size (Largest)";
+    case SortKey::SizeAscending:
+        return "Size (Smallest)";
+    case SortKey::ModifiedDescending:
+        return "Modified (Newest)";
+    case SortKey::ModifiedAscending:
+        return "Modified (Oldest)";
+    }
+    return "";
+}
+
+} // namespace ck::du
+


### PR DESCRIPTION
## Summary
- add SortKey metadata so directories and files keep precise timestamps for ordering
- integrate a global Sort menu that reorders directory outlines and file lists on demand
- document the new sort options in the ck-du README and tool guide

## Testing
- cmake --build build/dev
- ctest --test-dir build/dev --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68cfdc7464088330a6dab865eda5b077