### PR TITLE
Add asynchronous directory scanning with progress dialog

### DIFF
--- a/src/tools/ck-du/include/disk_usage_core.hpp
+++ b/src/tools/ck-du/include/disk_usage_core.hpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -61,7 +62,20 @@ struct FileEntry
     std::chrono::system_clock::time_point modifiedTime{};
 };
 
-std::unique_ptr<DirectoryNode> buildDirectoryTree(const std::filesystem::path &rootPath);
+struct BuildDirectoryTreeOptions
+{
+    std::function<void(const std::filesystem::path &)> progressCallback;
+    std::function<bool()> cancelRequested;
+};
+
+struct BuildDirectoryTreeResult
+{
+    std::unique_ptr<DirectoryNode> root;
+    bool cancelled = false;
+};
+
+BuildDirectoryTreeResult buildDirectoryTree(const std::filesystem::path &rootPath,
+                                            const BuildDirectoryTreeOptions &options = {});
 std::vector<FileEntry> listFiles(const std::filesystem::path &directory, bool recursive);
 
 SizeUnit getCurrentUnit() noexcept;


### PR DESCRIPTION
## Summary
- add cancellable background directory scanning in the core builder and surface progress callbacks
- show a progress dialog while scanning directories, allowing cancellation and keeping the UI responsive
- queue directory requests and rename the Actions menu to a View menu positioned before Help

## Testing
- cmake --build build/dev -t ck-du
- ctest --test-dir build/dev -R ckdu -V


------
https://chatgpt.com/codex/tasks/task_e_68cfebf933a4833080d3d33e377037ec