### PR TITLE
Add sort hotkeys to ck-du status bar

### DIFF
--- a/src/tools/ck-du/src/disk-usage-app.cpp
+++ b/src/tools/ck-du/src/disk-usage-app.cpp
@@ -345,10 +345,16 @@ private:
         auto *open = new TStatusItem("~F2~ Open", kbF2, cmOpen);
         auto *files = new TStatusItem("~F3~ Files", kbF3, cmViewFiles);
         auto *recursive = new TStatusItem("~Shift-F3~ Files+Sub", kbShiftF3, cmViewFilesRecursive);
+        auto *sortName = new TStatusItem("~Ctrl-N~ Sort Name", kbCtrlN, cmSortNameAsc);
+        auto *sortSize = new TStatusItem("~Ctrl-S~ Sort Size", kbCtrlS, cmSortSizeDesc);
+        auto *sortModified = new TStatusItem("~Ctrl-M~ Sort Modified", kbCtrlM, cmSortModifiedDesc);
         auto *quit = new TStatusItem("~Alt-X~ Quit", kbAltX, cmQuit);
         open->next = files;
         files->next = recursive;
-        recursive->next = quit;
+        recursive->next = sortName;
+        sortName->next = sortSize;
+        sortSize->next = sortModified;
+        sortModified->next = quit;
         items = open;
         defs->items = items;
         drawView();


### PR DESCRIPTION
## Summary
- extend the ck-du status bar to advertise Ctrl+N, Ctrl+S, and Ctrl+M shortcuts
- bind those shortcuts to sorting by name, by size (largest first), and by modified time (newest first)

## Testing
- cmake --preset dev
- cmake --build build/dev -t ck-du

------
https://chatgpt.com/codex/tasks/task_e_68cff72c952883309aeecab23cf39bf0