### PR TITLE
Adjust about dialog header layout and highlight color

### DIFF
--- a/include/ck/about_dialog.hpp
+++ b/include/ck/about_dialog.hpp
@@ -98,7 +98,17 @@ struct AboutDialogInfo
 inline std::string buildAboutDialogMessage(const AboutDialogInfo &info)
 {
     std::vector<std::string> paragraphs;
-    paragraphs.emplace_back(info.applicationName);
+    {
+        std::ostringstream headerOut;
+        headerOut << info.applicationName;
+        if (!info.copyright.empty())
+        {
+            if (!info.applicationName.empty())
+                headerOut << '\n';
+            headerOut << info.copyright;
+        }
+        paragraphs.emplace_back(headerOut.str());
+    }
     if (!info.toolName.empty())
         paragraphs.emplace_back(info.toolName);
 
@@ -121,11 +131,12 @@ inline std::string buildAboutDialogMessage(const AboutDialogInfo &info)
         paragraphs.emplace_back(buildOut.str());
     }
 
-    std::ostringstream developerOut;
-    developerOut << "Developer: " << info.developer;
-    if (!info.copyright.empty())
-        developerOut << "\n" << info.copyright;
-    paragraphs.emplace_back(developerOut.str());
+    if (!info.developer.empty())
+    {
+        std::ostringstream developerOut;
+        developerOut << "Developer: " << info.developer;
+        paragraphs.emplace_back(developerOut.str());
+    }
 
     std::ostringstream out;
     for (size_t i = 0; i < paragraphs.size(); ++i)
@@ -158,7 +169,8 @@ public:
     void draw() override
     {
         const TColorAttr normal = getColor(1);
-        const TColorAttr highlight = reverseAttribute(normal);
+        TColorAttr highlight = normal;
+        ::setFore(highlight, TColorBIOS(0x1));
         TDrawBuffer buffer;
         for (int y = 0; y < size.y; ++y)
         {


### PR DESCRIPTION
## Summary
- place the application copyright directly beneath the CK Utilities heading to avoid duplicating it in the developer block
- keep the developer line focused on author information only
- draw the highlighted heading with a dark blue foreground on the normal background instead of reversing the colors

## Testing
- cmake --preset dev
- cmake --build build/dev

------
https://chatgpt.com/codex/tasks/task_e_68d01d9de4fc8330b092a3b4f0b1e39a