### PR TITLE
Improve CLI help text and unify tool output directories

### DIFF
--- a/cmake/AddCkTool.cmake
+++ b/cmake/AddCkTool.cmake
@@ -13,6 +13,20 @@ function(add_ck_tool TOOL_NAME)
   add_executable(${TOOL_NAME} ${cktool_SOURCES})
   target_compile_features(${TOOL_NAME} PRIVATE cxx_std_20)
 
+  set(_ck_runtime_dir "${PROJECT_BINARY_DIR}/bin")
+  file(MAKE_DIRECTORY "${_ck_runtime_dir}")
+  set_target_properties(${TOOL_NAME} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${_ck_runtime_dir}"
+  )
+  if(CMAKE_CONFIGURATION_TYPES)
+    foreach(_ck_config ${CMAKE_CONFIGURATION_TYPES})
+      string(TOUPPER "${_ck_config}" _ck_config_upper)
+      set_target_properties(${TOOL_NAME} PROPERTIES
+        "RUNTIME_OUTPUT_DIRECTORY_${_ck_config_upper}" "${_ck_runtime_dir}"
+      )
+    endforeach()
+  endif()
+
   if(cktool_INCLUDE_DIRECTORIES)
     target_include_directories(${TOOL_NAME} PRIVATE ${cktool_INCLUDE_DIRECTORIES})
   endif()

--- a/src/tools/ck-config/src/config-app.cpp
+++ b/src/tools/ck-config/src/config-app.cpp
@@ -37,6 +37,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <unordered_set>
 #include <vector>
@@ -49,6 +50,10 @@ namespace config = ck::config;
 
 namespace
 {
+
+constexpr std::string_view kAppName = "ck-config";
+constexpr std::string_view kAppDescription =
+    "Manage ck-utilities configuration defaults.";
 
 using RegisterFn = void (*)(config::OptionRegistry &);
 
@@ -190,7 +195,8 @@ std::vector<ApplicationEntry> gatherApplicationEntries()
 
 void printUsage()
 {
-    std::cout << "Usage: ck-config [options]\n"
+    std::cout << kAppName << " - " << kAppDescription << "\n\n"
+              << "Usage: " << kAppName << " [options]\n"
               << "  --list-apps             List known applications\n"
               << "  --list-profiles         List profiles with saved defaults\n"
               << "  --config-root           Print the configuration root path\n"
@@ -1179,7 +1185,7 @@ public:
                 showConfigDirectory();
                 break;
             case cmAbout:
-                ck::ui::showAboutDialog("ck-config", CK_CONFIG_VERSION, "Manage ck-utilities configuration defaults.");
+                ck::ui::showAboutDialog(kAppName, CK_CONFIG_VERSION, kAppDescription);
                 break;
             default:
                 return;

--- a/src/tools/ck-du/src/disk-usage-app.cpp
+++ b/src/tools/ck-du/src/disk-usage-app.cpp
@@ -2481,7 +2481,8 @@ int main(int argc, char **argv)
     std::vector<std::filesystem::path> directories;
 
     auto printUsage = []() {
-        std::cout << "Usage: ck-du [options] [paths...]\n"
+        std::cout << "ck-du - " << kAboutDescription << "\n\n"
+                  << "Usage: ck-du [options] [paths...]\n"
                   << "  -H             Follow symlinks listed on the command line only\n"
                   << "  -L             Follow all symbolic links\n"
                   << "  -P             Do not follow symbolic links\n"

--- a/src/tools/ck-edit/include/ck/edit/markdown_editor.hpp
+++ b/src/tools/ck-edit/include/ck/edit/markdown_editor.hpp
@@ -39,6 +39,10 @@
 namespace ck::edit
 {
 
+inline constexpr std::string_view kAppName = "ck-edit";
+inline constexpr std::string_view kAppDescription =
+    "Edit text and Markdown documents with live structural hints.";
+
 class MarkdownInfoView;
 
 class MarkdownFileEditor : public TFileEditor

--- a/src/tools/ck-edit/src/ck-edit-app.cpp
+++ b/src/tools/ck-edit/src/ck-edit-app.cpp
@@ -1,7 +1,36 @@
 #include "ck/edit/markdown_editor.hpp"
 
+#include <iostream>
+#include <string_view>
+
+namespace
+{
+
+void printHelp()
+{
+    std::cout << ck::edit::kAppName << " - " << ck::edit::kAppDescription << "\n\n";
+    std::cout << "Usage: " << ck::edit::kAppName << " [FILE...]\n";
+    std::cout << "Launch the editor and open each FILE provided on the command line." << std::endl;
+}
+
+bool isHelpFlag(std::string_view arg)
+{
+    return arg == "--help" || arg == "-h";
+}
+
+} // namespace
+
 int main(int argc, char **argv)
 {
+    for (int i = 1; i < argc; ++i)
+    {
+        if (isHelpFlag(std::string_view{argv[i]}))
+        {
+            printHelp();
+            return 0;
+        }
+    }
+
     ck::edit::MarkdownEditorApp app(argc, argv);
     app.run();
     app.shutDown();

--- a/src/tools/ck-edit/src/markdown_editor.cpp
+++ b/src/tools/ck-edit/src/markdown_editor.cpp
@@ -2641,8 +2641,7 @@ void MarkdownEditorApp::changeDir()
 
 void MarkdownEditorApp::showAbout()
 {
-    ck::ui::showAboutDialog("ck-edit", CK_EDIT_VERSION,
-                            "Edit text and Markdown documents with live structural hints.");
+    ck::ui::showAboutDialog(kAppName, CK_EDIT_VERSION, kAppDescription);
 }
 
 void MarkdownEditorApp::dispatchToEditor(ushort command)


### PR DESCRIPTION
## Summary
- share ck-edit metadata across the UI and add a `--help` handler that prints the program description and file-loading usage details
- include the program name and tagline in the ck-du and ck-config help text for consistency with their about dialogs
- configure `add_ck_tool` so tool binaries (including ck-json-view) are emitted to the build `bin` directory alongside the other utilities

## Testing
- cmake --preset dev
- cmake --build build/dev
- ctest --test-dir build/dev
- build/dev/bin/ck-edit --help
- build/dev/bin/ck-du --help | head -n 4
- build/dev/bin/ck-config --help | head -n 4


------
https://chatgpt.com/codex/tasks/task_e_68d01e62d80083308f1fa3178899a45a