### PR TITLE
Add filtered file list launch from type summary

### DIFF
--- a/src/tools/ck-du/include/disk_usage_core.hpp
+++ b/src/tools/ck-du/include/disk_usage_core.hpp
@@ -63,6 +63,13 @@ struct FileEntry
     std::chrono::system_clock::time_point modifiedTime{};
 };
 
+struct FileTypeSummary
+{
+    std::string type;
+    std::uintmax_t totalSize = 0;
+    std::size_t count = 0;
+};
+
 struct BuildDirectoryTreeOptions
 {
     std::function<void(const std::filesystem::path &)> progressCallback;
@@ -93,6 +100,13 @@ BuildDirectoryTreeResult buildDirectoryTree(const std::filesystem::path &rootPat
                                             const BuildDirectoryTreeOptions &options = {});
 std::vector<FileEntry> listFiles(const std::filesystem::path &directory, bool recursive,
                                 const BuildDirectoryTreeOptions &options = {});
+
+std::vector<FileTypeSummary> summarizeFileTypes(const std::filesystem::path &directory, bool recursive,
+                                                const BuildDirectoryTreeOptions &options = {});
+
+std::vector<FileEntry> listFilesByType(const std::filesystem::path &directory, bool recursive,
+                                       const std::string &type,
+                                       const BuildDirectoryTreeOptions &options = {});
 
 SizeUnit getCurrentUnit() noexcept;
 void setCurrentUnit(SizeUnit unit) noexcept;


### PR DESCRIPTION
## Summary
- add a `listFilesByType` helper that reuses file-type detection to produce filtered file entries
- extend the file-type window to remember its scan context, handle Enter, and ask the app to open a matching file list
- wire the application to launch filtered file lists and teach the status line to hint at the new shortcut

## Testing
- cmake --preset dev
- cmake --build build/dev -t ck-du
- ctest --test-dir build/dev -R ck-du

------
https://chatgpt.com/codex/tasks/task_e_68d04c0b16bc8330b009880df8a4c371