### PR TITLE
Implement save workflows and status feedback in ck-edit

### DIFF
--- a/src/tools/ck-edit/include/ck/edit/markdown_editor.hpp
+++ b/src/tools/ck-edit/include/ck/edit/markdown_editor.hpp
@@ -4,6 +4,7 @@
 #include "ck/app_info.hpp"
 
 #define Uses_TWindow
+#define Uses_TFrame
 #define Uses_TScrollBar
 #define Uses_TIndicator
 #define Uses_TView
@@ -32,6 +33,7 @@
 #define Uses_TObject
 #include <tvision/tv.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -248,9 +250,12 @@ public:
     MarkdownEditWindow(const TRect &bounds, TStringView fileName, int aNumber) noexcept;
     MarkdownFileEditor *editor() noexcept { return fileEditor; }
     void updateLayoutForMode();
+    void updateWindowTitle();
+    bool saveDocument(bool forceSaveAs);
 
     virtual void draw() override;
     virtual void setState(ushort aState, Boolean enable) override;
+    virtual void handleEvent(TEvent &event) override;
 
 private:
     MarkdownFileEditor *fileEditor = nullptr;
@@ -258,6 +263,8 @@ private:
     TScrollBar *hScrollBar = nullptr;
     TScrollBar *vScrollBar = nullptr;
     TIndicator *indicator = nullptr;
+
+    void applyWindowTitle(const std::string &titleText);
 };
 
 class MarkdownEditorApp : public TApplication
@@ -269,10 +276,12 @@ public:
     static TStatusLine *initStatusLine(TRect);
 
     virtual void handleEvent(TEvent &event) override;
+    virtual void idle() override;
 
     void updateStatusLineForMode(bool markdownMode);
     void updateMenuBarForMode(bool markdownMode);
     void refreshUiMode();
+    void showDocumentSavedMessage(const std::string &path);
 
 private:
     MarkdownEditWindow *openEditor(const char *fileName, Boolean visible);
@@ -281,6 +290,11 @@ private:
     void changeDir();
     void showAbout();
     void dispatchToEditor(ushort command);
+    void clearStatusMessage();
+
+    std::atomic<uint32_t> statusMessageCounter = 0;
+    std::atomic<uint32_t> activeStatusMessageToken = 0;
+    std::atomic<uint32_t> pendingStatusMessageClear = 0;
 };
 
 } // namespace ck::edit

--- a/src/tools/ck-edit/src/markdown_editor.cpp
+++ b/src/tools/ck-edit/src/markdown_editor.cpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <chrono>
+#include <thread>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -25,6 +27,11 @@ constexpr int kInfoColumnWidth = 20;
 
 const std::array<std::string_view, 7> kMarkdownExtensions = {
     ".md", ".markdown", ".mdown", ".mkd", ".mkdn", ".mdtxt", ".mdtext"};
+
+void delay(unsigned milliseconds)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
+}
 
 const ushort cmToggleWrap = 3000;
 const ushort cmToggleMarkdownMode = 3001;
@@ -165,6 +172,24 @@ public:
             defs->items = nullptr;
     }
 
+    void showTemporaryMessage(const std::string &message)
+    {
+        temporaryMessage = message;
+        showingTemporaryMessage = true;
+        drawView();
+    }
+
+    void clearTemporaryMessage()
+    {
+        if (!showingTemporaryMessage)
+            return;
+        showingTemporaryMessage = false;
+        temporaryMessage.clear();
+        drawView();
+    }
+
+    bool hasTemporaryMessage() const noexcept { return showingTemporaryMessage; }
+
     void setMarkdownMode(bool markdownMode)
     {
         disposeItems(items);
@@ -195,6 +220,13 @@ public:
         drawView();
     }
 
+    virtual const char *hint(ushort helpCtx) override
+    {
+        if (showingTemporaryMessage)
+            return temporaryMessage.c_str();
+        return TStatusLine::hint(helpCtx);
+    }
+
 private:
     void disposeItems(TStatusItem *item)
     {
@@ -205,6 +237,9 @@ private:
             item = next;
         }
     }
+
+    std::string temporaryMessage;
+    bool showingTemporaryMessage = false;
 };
 
 TSubMenu &makeFileMenu()
@@ -2340,6 +2375,20 @@ void MarkdownFileEditor::handleEvent(TEvent &event)
     {
         switch (event.message.command)
         {
+        case cmSave:
+            if (hostWindow)
+                hostWindow->saveDocument(false);
+            else
+                save();
+            clearEvent(event);
+            return;
+        case cmSaveAs:
+            if (hostWindow)
+                hostWindow->saveDocument(true);
+            else
+                saveAs();
+            clearEvent(event);
+            return;
         case cmToggleWrap:
             toggleWrap();
             clearEvent(event);
@@ -2636,6 +2685,8 @@ void MarkdownFileEditor::notifyInfoView()
 void MarkdownFileEditor::onContentModified()
 {
     notifyInfoView();
+    if (hostWindow)
+        hostWindow->updateWindowTitle();
 }
 
 std::string MarkdownFileEditor::makeTableRow(const std::vector<std::string> &cells) const
@@ -2841,6 +2892,7 @@ MarkdownEditWindow::MarkdownEditWindow(const TRect &bounds, TStringView fileName
     fileEditor->setInfoView(infoView);
     fileEditor->setHostWindow(this);
     updateLayoutForMode();
+    updateWindowTitle();
 }
 
 void MarkdownEditWindow::updateLayoutForMode()
@@ -2879,6 +2931,77 @@ void MarkdownEditWindow::updateLayoutForMode()
 
     if (auto *app = dynamic_cast<MarkdownEditorApp *>(TProgram::application))
         app->refreshUiMode();
+}
+
+void MarkdownEditWindow::applyWindowTitle(const std::string &titleText)
+{
+    if (title)
+    {
+        delete[] const_cast<char *>(title);
+        title = nullptr;
+    }
+    title = newStr(titleText.c_str());
+    if (frame)
+        frame->drawView();
+}
+
+void MarkdownEditWindow::updateWindowTitle()
+{
+    if (!fileEditor)
+        return;
+
+    std::string displayName;
+    if (fileEditor->fileName[0] != '\0')
+    {
+        std::filesystem::path path(fileEditor->fileName);
+        displayName = path.filename().string();
+        if (displayName.empty())
+            displayName = path.string();
+    }
+    else
+    {
+        displayName = "Untitled";
+    }
+
+    if (fileEditor->modified)
+        displayName.insert(0, "* ");
+
+    applyWindowTitle(displayName);
+}
+
+bool MarkdownEditWindow::saveDocument(bool forceSaveAs)
+{
+    if (!fileEditor)
+        return false;
+
+    std::string previousName = fileEditor->fileName;
+    bool saved = forceSaveAs ? static_cast<bool>(fileEditor->saveAs())
+                             : static_cast<bool>(fileEditor->save());
+    if (!saved)
+        return false;
+
+    std::string newName = fileEditor->fileName;
+    if (previousName != newName && !newName.empty())
+        fileEditor->setMarkdownMode(isMarkdownFile(newName));
+
+    updateWindowTitle();
+
+    std::string savedPath = newName.empty() ? std::string("Untitled") : newName;
+
+    if (auto *app = dynamic_cast<MarkdownEditorApp *>(TProgram::application))
+        app->showDocumentSavedMessage(savedPath);
+
+    return true;
+}
+
+void MarkdownEditWindow::handleEvent(TEvent &event)
+{
+    TWindow::handleEvent(event);
+    if (event.what == evBroadcast && event.message.command == cmUpdateTitle)
+    {
+        updateWindowTitle();
+        clearEvent(event);
+    }
 }
 
 void MarkdownEditWindow::draw()
@@ -2975,6 +3098,35 @@ void MarkdownEditorApp::dispatchToEditor(ushort command)
     win->editor()->handleEvent(ev);
 }
 
+void MarkdownEditorApp::showDocumentSavedMessage(const std::string &path)
+{
+    if (!statusLine)
+        return;
+    auto *line = dynamic_cast<MarkdownStatusLine *>(statusLine);
+    if (!line)
+        return;
+
+    std::string message = "Document saved: " + path;
+    line->showTemporaryMessage(message);
+
+    const uint32_t token = statusMessageCounter.fetch_add(1, std::memory_order_relaxed) + 1;
+    activeStatusMessageToken.store(token, std::memory_order_release);
+    pendingStatusMessageClear.store(0, std::memory_order_release);
+
+    std::thread([this, token]() {
+        delay(3000);
+        pendingStatusMessageClear.store(token, std::memory_order_release);
+    }).detach();
+}
+
+void MarkdownEditorApp::clearStatusMessage()
+{
+    if (!statusLine)
+        return;
+    if (auto *line = dynamic_cast<MarkdownStatusLine *>(statusLine))
+        line->clearTemporaryMessage();
+}
+
 void MarkdownEditorApp::handleEvent(TEvent &event)
 {
     TApplication::handleEvent(event);
@@ -2995,6 +3147,10 @@ void MarkdownEditorApp::handleEvent(TEvent &event)
         break;
     case cmChangeDir:
         changeDir();
+        break;
+    case cmSave:
+    case cmSaveAs:
+        dispatchToEditor(event.message.command);
         break;
     case cmToggleWrap:
     case cmToggleMarkdownMode:
@@ -3057,6 +3213,30 @@ void MarkdownEditorApp::handleEvent(TEvent &event)
     if (handled)
         clearEvent(event);
     refreshUiMode();
+}
+
+void MarkdownEditorApp::idle()
+{
+    TApplication::idle();
+
+    uint32_t token = pendingStatusMessageClear.load(std::memory_order_acquire);
+    if (token == 0)
+        return;
+
+    uint32_t active = activeStatusMessageToken.load(std::memory_order_acquire);
+    if (token == active)
+    {
+        clearStatusMessage();
+        pendingStatusMessageClear.store(0, std::memory_order_release);
+        activeStatusMessageToken.store(0, std::memory_order_release);
+    }
+    else
+    {
+        uint32_t expected = token;
+        pendingStatusMessageClear.compare_exchange_strong(expected, 0,
+                                                          std::memory_order_acq_rel,
+                                                          std::memory_order_acquire);
+    }
 }
 
 TMenuBar *MarkdownEditorApp::initMenuBar(TRect r)


### PR DESCRIPTION
## Summary
- add save/save-as orchestration in `MarkdownEditWindow`, update titles with dirty markers, and adjust markdown mode after renames
- surface document saved notifications via a temporary status line message driven by an asynchronous delay
- forward save commands from the application layer and refresh UI state whenever the buffer changes

## Testing
- cmake --build --preset dev --target ck-edit

------
https://chatgpt.com/codex/tasks/task_e_68d052ed8c6883308518d631ed4b71d4