### PR TITLE
Focus launcher list by default

### DIFF
--- a/src/tools/ck-utilities/src/ck-utilities-app.cpp
+++ b/src/tools/ck-utilities/src/ck-utilities-app.cpp
@@ -584,7 +584,10 @@ public:
         layoutChildren();
 
         if (!toolRefs.empty())
+        {
             listView->focusItem(0);
+            listView->select();
+        }
 
         ensureDetailUpdated();
     }


### PR DESCRIPTION
## Summary
- ensure the ck-utilities launcher dialog selects the tool list when opened
- keep the default Launch button while directing initial focus to the list view

## Testing
- cmake --build --preset dev --target ck-utilities

------
https://chatgpt.com/codex/tasks/task_e_68d0686304d48330921d8d6017029ec2