### PR TITLE
Add return-to-launcher workflow across CK tools

### DIFF
--- a/include/ck/launcher.hpp
+++ b/include/ck/launcher.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+
+namespace ck::launcher
+{
+
+inline constexpr const char kLauncherEnvVar[] = "CK_LAUNCHED_FROM";
+inline constexpr const char kLauncherEnvValue[] = "ck-utilities";
+inline constexpr int kReturnToLauncherExitCode = 247; // Arbitrary non-zero code reserved for returning to the launcher.
+
+inline bool launchedFromCkLauncher()
+{
+    const char *value = std::getenv(kLauncherEnvVar);
+    return value && std::strcmp(value, kLauncherEnvValue) == 0;
+}
+
+} // namespace ck::launcher

--- a/src/tools/ck-edit/src/markdown_editor.cpp
+++ b/src/tools/ck-edit/src/markdown_editor.cpp
@@ -1,11 +1,13 @@
 #include "ck/edit/markdown_editor.hpp"
 
 #include "ck/about_dialog.hpp"
+#include "ck/launcher.hpp"
 
 #include <algorithm>
 #include <array>
 #include <cctype>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <optional>
@@ -84,6 +86,7 @@ const ushort cmReflowParagraphs = 3070;
 const ushort cmFormatDocument = 3071;
 const ushort cmToggleSmartList = 3080;
 const ushort cmAbout = 3090;
+const ushort cmReturnToLauncher = 3091;
 
 bool equalsIgnoreCase(std::string_view lhs, std::string_view rhs) noexcept
 {
@@ -163,10 +166,11 @@ struct CommandHotkey
     const char *label;
 };
 
-const std::array<CommandHotkey, 52> kCommandHotkeys = {{
+const std::array<CommandHotkey, 53> kCommandHotkeys = {{
     {cmOpen, TKey(kbF3), "~F3~ Open"},
     {cmSave, TKey(kbF2), "~F2~ Save"},
     {cmSaveAs, TKey(kbShiftF12), "~Shift-F12~ Save As"},
+    {cmReturnToLauncher, TKey(kbCtrlL), "~Ctrl-L~ Return"},
     {cmToggleWrap, TKey(kbCtrlW), "~Ctrl-W~ Wrap"},
     {cmToggleMarkdownMode, TKey(kbCtrlM), "~Ctrl-M~ Markdown"},
     {cmBold, TKey(kbCtrlB), "~Ctrl-B~ Bold"},
@@ -253,6 +257,8 @@ std::vector<ushort> buildBaseCommands(const MarkdownStatusContext &context)
     if (!context.hasEditor)
     {
         commands.push_back(cmOpen);
+        if (ck::launcher::launchedFromCkLauncher())
+            commands.push_back(cmReturnToLauncher);
         return commands;
     }
 
@@ -261,6 +267,8 @@ std::vector<ushort> buildBaseCommands(const MarkdownStatusContext &context)
         commands.push_back(cmSaveAs);
     commands.push_back(cmToggleWrap);
     commands.push_back(cmToggleMarkdownMode);
+    if (ck::launcher::launchedFromCkLauncher())
+        commands.push_back(cmReturnToLauncher);
     return commands;
 }
 
@@ -537,14 +545,17 @@ private:
 
 TSubMenu &makeFileMenu()
 {
-    return *new TSubMenu("~F~ile", kbAltF) +
-           *new TMenuItem("~O~pen", cmOpen, kbF3, hcNoContext, "F3") +
-           *new TMenuItem("~N~ew", cmNew, kbCtrlN, hcNoContext, "Ctrl-N") +
-           *new TMenuItem("~S~ave", cmSave, kbF2, hcNoContext, "F2") +
-           *new TMenuItem("S~a~ve as...", cmSaveAs, kbNoKey) +
-           newLine() +
-           *new TMenuItem("~C~hange dir...", cmChangeDir, kbNoKey) +
-           *new TMenuItem("E~x~it", cmQuit, kbCtrlQ, hcNoContext, "Ctrl-Q");
+    TSubMenu &menu = *new TSubMenu("~F~ile", kbAltF) +
+                     *new TMenuItem("~O~pen", cmOpen, kbF3, hcNoContext, "F3") +
+                     *new TMenuItem("~N~ew", cmNew, kbCtrlN, hcNoContext, "Ctrl-N") +
+                     *new TMenuItem("~S~ave", cmSave, kbF2, hcNoContext, "F2") +
+                     *new TMenuItem("S~a~ve as...", cmSaveAs, kbNoKey) +
+                     newLine() +
+                     *new TMenuItem("~C~hange dir...", cmChangeDir, kbNoKey);
+    if (ck::launcher::launchedFromCkLauncher())
+        menu + *new TMenuItem("Return to ~L~auncher", cmReturnToLauncher, kbCtrlL, hcNoContext, "Ctrl-L");
+    menu + *new TMenuItem("E~x~it", cmQuit, kbCtrlQ, hcNoContext, "Ctrl-Q");
+    return menu;
 }
 
 TSubMenu &makeHeadingsMenu()
@@ -3624,6 +3635,9 @@ void MarkdownEditorApp::handleEvent(TEvent &event)
     case cmFormatDocument:
     case cmToggleSmartList:
         dispatchToEditor(event.message.command);
+        break;
+    case cmReturnToLauncher:
+        std::exit(ck::launcher::kReturnToLauncherExitCode);
         break;
     case cmAbout:
         showAbout();


### PR DESCRIPTION
## Summary
- add a shared launcher utility header that defines the environment flag and exit code used to signal the ck-utilities launcher
- update the ck-utilities launcher to set the environment flag when launching tools, recognize the special return code, and exit itself when tools quit normally
- teach ck-config, ck-du, ck-edit, and json-view to detect launcher launches, expose a "Return to Launcher" command, and exit with the special return code when selected

## Testing
- cmake --build --preset dev
- ctest --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68d067e4be888330a13a7f4b6355bdb9