### PR TITLE
Fix initial menu focus in ck-edit

### DIFF
--- a/src/tools/ck-edit/src/markdown_editor.cpp
+++ b/src/tools/ck-edit/src/markdown_editor.cpp
@@ -755,7 +755,7 @@ public:
         TMenu *newMenu = buildMenu(mode);
         delete menu;
         menu = newMenu;
-        current = menu ? menu->items : nullptr;
+        current = nullptr;
         drawView();
     }
 


### PR DESCRIPTION
## Summary
- prevent the ck-edit menu bar from forcing the File menu to appear focused when switching modes

## Testing
- cmake --preset dev
- cmake --build build/dev -t ck-edit

------
https://chatgpt.com/codex/tasks/task_e_68d06bcb8cf08330bb21cad4812cd8e3