### PR TITLE
Queue launcher command to avoid segfault

### DIFF
--- a/src/tools/ck-utilities/src/ck-utilities-app.cpp
+++ b/src/tools/ck-utilities/src/ck-utilities-app.cpp
@@ -631,7 +631,14 @@ public:
         TDialog::handleEvent(event);
         if (event.what == evCommand && event.message.command == cmLaunchTool)
         {
-            message(TProgram::application, evCommand, cmLaunchTool, this);
+            if (TProgram::application)
+            {
+                TEvent launchEvent{};
+                launchEvent.what = evCommand;
+                launchEvent.message.command = cmLaunchTool;
+                launchEvent.message.infoPtr = this;
+                TProgram::application->putEvent(launchEvent);
+            }
             clearEvent(event);
             return;
         }


### PR DESCRIPTION
## Summary
- queue launch commands from the dialog instead of dispatching them synchronously
- ensure the application handles the launch after the button handler finishes to avoid use-after-free

## Testing
- `ctest --test-dir build/dev --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68d06f7c7d108330a918270256c4638a