### PR TITLE
Fix markdown editor cursor tracking with wrap

### DIFF
--- a/src/tools/ck-edit/include/ck/edit/markdown_editor.hpp
+++ b/src/tools/ck-edit/include/ck/edit/markdown_editor.hpp
@@ -182,6 +182,9 @@ public:
     uint topLinePointer();
     std::string lineText(uint linePtr);
     void notifyInfoView();
+    void refreshCursorMetrics();
+    int documentLineNumber() const noexcept;
+    int documentColumnNumber() const noexcept;
     uint stateVersion() const noexcept { return cachedStateVersion; }
     void buildStatusContext(struct MarkdownStatusContext &context);
 
@@ -203,6 +206,8 @@ private:
     bool lineNumberCacheValid = false;
     uint lineNumberCachePtr = 0;
     int lineNumberCacheNumber = 0;
+    int cursorLineNumber = 0;
+    int cursorColumnNumber = 0;
 
     void onContentModified();
     void queueInfoLine(int lineNumber);
@@ -213,6 +218,7 @@ private:
     uint pointerForLine(int lineNumber);
     void enqueuePendingInfoLine(int lineNumber);
     void resetLineNumberCache();
+    int computeLineNumberForPointer(uint pointer);
     void applyInlineCommand(const InlineCommandSpec &spec);
     void removeFormattingAround(uint start, uint end);
     bool ensureSelection();


### PR DESCRIPTION
## Summary
- track the document line and column at the caret and keep the indicator aligned after refreshing cursor metrics
- refresh cursor metrics around event handling and reuse the physical line number when queueing incremental info view updates
- highlight and locate info view rows using document coordinates so the left pane follows the wrapped caret correctly

## Testing
- `cmake --build build/dev -t ck-edit`
- `ctest --test-dir build/dev -R ck_edit` *(fails: test target is not built)*

------
https://chatgpt.com/codex/tasks/task_e_68d1949c884c83309bb897cd4a2b609c