### PR TITLE
Ensure CI installs curl dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,22 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build libncursesw5-dev
+          sudo apt-get install -y ninja-build libncursesw5-dev libcurl4-openssl-dev
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
           brew update
-          brew install ninja ncurses
+          brew install ninja ncurses curl
           NCURSES_PREFIX=$(brew --prefix ncurses)
           echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}$NCURSES_PREFIX" >> "$GITHUB_ENV"
           echo "CPATH=${CPATH:+$CPATH:}$NCURSES_PREFIX/include" >> "$GITHUB_ENV"
           echo "LIBRARY_PATH=${LIBRARY_PATH:+$LIBRARY_PATH:}$NCURSES_PREFIX/lib" >> "$GITHUB_ENV"
+          CURL_PREFIX=$(brew --prefix curl)
+          echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}$CURL_PREFIX/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}$CURL_PREFIX" >> "$GITHUB_ENV"
+          echo "CPATH=${CPATH:+$CPATH:}$CURL_PREFIX/include" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=${LIBRARY_PATH:+$LIBRARY_PATH:}$CURL_PREFIX/lib" >> "$GITHUB_ENV"
 
       - name: Configure
         run: cmake --preset dev
@@ -52,7 +57,7 @@ jobs:
       - name: Install packaging dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y ninja-build libncursesw5-dev rpm
+          sudo apt-get install -y ninja-build libncursesw5-dev libcurl4-openssl-dev rpm
 
       - name: Configure
         run: cmake --preset pkg
@@ -82,11 +87,16 @@ jobs:
       - name: Install packaging dependencies
         run: |
           brew update
-          brew install ninja ncurses
+          brew install ninja ncurses curl
           NCURSES_PREFIX=$(brew --prefix ncurses)
           echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}$NCURSES_PREFIX" >> "$GITHUB_ENV"
           echo "CPATH=${CPATH:+$CPATH:}$NCURSES_PREFIX/include" >> "$GITHUB_ENV"
           echo "LIBRARY_PATH=${LIBRARY_PATH:+$LIBRARY_PATH:}$NCURSES_PREFIX/lib" >> "$GITHUB_ENV"
+          CURL_PREFIX=$(brew --prefix curl)
+          echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}$CURL_PREFIX/lib/pkgconfig" >> "$GITHUB_ENV"
+          echo "CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+$CMAKE_PREFIX_PATH:}$CURL_PREFIX" >> "$GITHUB_ENV"
+          echo "CPATH=${CPATH:+$CPATH:}$CURL_PREFIX/include" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=${LIBRARY_PATH:+$LIBRARY_PATH:}$CURL_PREFIX/lib" >> "$GITHUB_ENV"
 
       - name: Configure
         run: cmake --preset pkg -DCMAKE_INSTALL_PREFIX=.


### PR DESCRIPTION
## Summary
- install libcurl development packages in CI to satisfy CMake curl checks
- export curl paths on macOS runners so pkg-config can locate the library

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68fc90f6700c83309cc741bbac78402d